### PR TITLE
Add text3ds.h to bindgen

### DIFF
--- a/citro3d-sys/bindgen.sh
+++ b/citro3d-sys/bindgen.sh
@@ -19,9 +19,11 @@ bindgen "$DEVKITPRO/libctru/include/tex3ds.h" \
     --allowlist-type "C3D_.*" \
     --allowlist-type "Tex3DS_.*" \
     --allowlist-type "DVLB_.*" \
+    --allowlist-type "LightLut.*" \
     --allowlist-type "shader.*" \
     --allowlist-type "float24Uniform_s" \
     --allowlist-function "C3D_.*" \
+    --allowlist-function "LightLut_.*" \
     --allowlist-function "Tex3DS_.*" \
     --allowlist-function "shader.*" \
     --allowlist-function "DVLB_.*" \

--- a/citro3d-sys/src/bindings.rs
+++ b/citro3d-sys/src/bindings.rs
@@ -2378,6 +2378,17 @@ pub struct C3D_LightLutDA {
 pub type C3D_LightLutFunc = ::core::option::Option<unsafe extern "C" fn(x: f32, param: f32) -> f32>;
 pub type C3D_LightLutFuncDA =
     ::core::option::Option<unsafe extern "C" fn(dist: f32, arg0: f32, arg1: f32) -> f32>;
+extern "C" {
+    pub fn LightLut_FromArray(lut: *mut C3D_LightLut, data: *mut f32);
+}
+extern "C" {
+    pub fn LightLut_FromFunc(
+        lut: *mut C3D_LightLut,
+        func: C3D_LightLutFunc,
+        param: f32,
+        negative: bool,
+    );
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct C3D_Material {


### PR DESCRIPTION
Solves #6 
I've made this PR a draft as I'm not sure if you need me to get on a Linux vm and actually gen the bindings or not. I'm gonna be busy this weekend so if you are happy with the pr you can make it reviewable and merge it

Changes:
 - change bindgen.sh to use `tex3ds.h` as it includes `citro3d.h`