### PR TITLE
citro2d-rs requirements

### DIFF
--- a/citro3d/src/render.rs
+++ b/citro3d/src/render.rs
@@ -79,6 +79,14 @@ impl<'screen> Target<'screen> {
         })
     }
 
+    /// Create a new render target from a pre-computed C3D_RenderTarget.
+    pub fn new_computed(raw: *mut C3D_RenderTarget, screen: RefMut<'screen, dyn Screen>) -> Self {
+        Self {
+            raw,
+            _screen: screen
+        }
+    }
+
     /// Clear the render target with the given 32-bit RGBA color and depth buffer value.
     /// Use `flags` to specify whether color and/or depth should be overwritten.
     pub fn clear(&mut self, flags: ClearFlags, rgba_color: u32, depth: u32) {
@@ -88,7 +96,7 @@ impl<'screen> Target<'screen> {
     }
 
     /// Return the underlying `citro3d` render target for this target.
-    pub(crate) fn as_raw(&self) -> *mut C3D_RenderTarget {
+    pub fn as_raw(&self) -> *mut C3D_RenderTarget {
         self.raw
     }
 }


### PR DESCRIPTION
I started writing a wrapper with bindings for citro2d and it uses its own function to instantiate and configure a C3D_RenderTarget. 
Because citro2d relies on citro3d I think citro2d-rs should integrate with citro3d-rs as much as possible. 
The C3D_RenderTarget can't be used outside of the wrapper if the raw pointer is crate-private.

It's the first time I write bindings and wrap an existing library code, so I'm probably doing a lot of mistakes.
For now the [code](https://github.com/thecatcore/citro2d-rs) is heavily inspired by citro3d-rs and citru-rs.