### PR TITLE
Start porting <c3d/maths.h>, vectors and matrices

### DIFF
--- a/citro3d-macros/src/lib.rs
+++ b/citro3d-macros/src/lib.rs
@@ -1,3 +1,5 @@
+//! Procedural macro helpers for `citro3d`.
+
 // we're already nightly-only so might as well use unstable proc macro APIs.
 #![feature(proc_macro_span)]
 

--- a/citro3d/examples/triangle.rs
+++ b/citro3d/examples/triangle.rs
@@ -91,7 +91,7 @@ fn main() {
 
     scene_init(&mut program);
 
-    let projection_uniform_idx = program.get_uniform_location("projection").unwrap();
+    let projection_uniform_idx = program.get_uniform("projection").unwrap();
 
     while apt.main_loop() {
         hid.scan_input();
@@ -109,7 +109,7 @@ fn main() {
                 let clear_color: u32 = 0x7F_7F_7F_FF;
                 target.clear(ClearFlags::ALL, clear_color, 0);
 
-                instance.update_vertex_uniform_mat4x4(projection_uniform_idx, projection);
+                instance.bind_vertex_uniform(projection_uniform_idx, projection);
 
                 instance.set_attr_info(&attr_info);
 

--- a/citro3d/examples/triangle.rs
+++ b/citro3d/examples/triangle.rs
@@ -3,13 +3,10 @@
 
 #![feature(allocator_api)]
 
-use std::ffi::CStr;
-use std::mem::MaybeUninit;
-
 use citro3d::macros::include_shader;
+use citro3d::math::{CoordinateSystem, Matrix};
 use citro3d::render::{self, ClearFlags};
-use citro3d::{attrib, buffer, shader};
-use citro3d_sys::C3D_Mtx;
+use citro3d::{attrib, buffer, shader, AspectRatio};
 use ctru::prelude::*;
 use ctru::services::gfx::{RawFrameBuffer, Screen, TopScreen3D};
 
@@ -92,7 +89,10 @@ fn main() {
     let mut buf_info = buffer::Info::new();
     let (attr_info, vbo_idx) = prepare_vbos(&mut buf_info, &vbo_data);
 
-    let projection_uniform_idx = scene_init(&mut program);
+    scene_init(&mut program);
+
+    let projection_uniform_idx = program.get_uniform_location("projection").unwrap();
+
     while apt.main_loop() {
         hid.scan_input();
 
@@ -109,14 +109,7 @@ fn main() {
                 let clear_color: u32 = 0x7F_7F_7F_FF;
                 target.clear(ClearFlags::ALL, clear_color, 0);
 
-                unsafe {
-                    // Update the uniforms
-                    citro3d_sys::C3D_FVUnifMtx4x4(
-                        ctru_sys::GPU_VERTEX_SHADER,
-                        projection_uniform_idx.into(),
-                        projection,
-                    );
-                }
+                instance.update_vertex_uniform_mat4x4(projection_uniform_idx, projection);
 
                 instance.set_attr_info(&attr_info);
 
@@ -165,16 +158,12 @@ where
 }
 
 struct Projections {
-    left: C3D_Mtx,
-    right: C3D_Mtx,
-    center: C3D_Mtx,
+    left: Matrix,
+    right: Matrix,
+    center: Matrix,
 }
 
 fn calculate_projections() -> Projections {
-    let mut left_eye = MaybeUninit::uninit();
-    let mut right_eye = MaybeUninit::uninit();
-    let mut center = MaybeUninit::uninit();
-
     // TODO: it would be cool to allow playing around with these parameters on
     // the fly with D-pad, etc.
     let slider_val = unsafe { ctru_sys::osGet3DSliderState() };
@@ -182,53 +171,48 @@ fn calculate_projections() -> Projections {
 
     let near = 0.01;
     let far = 100.0;
-    let fovy = 40.0_f32.to_radians();
+    let fov_y = 40.0_f32.to_radians();
     let screen = 2.0;
 
-    unsafe {
-        citro3d_sys::Mtx_PerspStereoTilt(
-            left_eye.as_mut_ptr(),
-            fovy,
-            citro3d_sys::C3D_AspectRatioTop as f32,
-            near,
-            far,
-            -iod,
-            screen,
-            true,
-        );
+    let left_eye = Matrix::perspective_stereo_tilt(
+        fov_y,
+        AspectRatio::TopScreen,
+        near,
+        far,
+        -iod,
+        screen,
+        CoordinateSystem::LeftHanded,
+    );
 
-        citro3d_sys::Mtx_PerspStereoTilt(
-            right_eye.as_mut_ptr(),
-            fovy,
-            citro3d_sys::C3D_AspectRatioTop as f32,
-            near,
-            far,
-            iod,
-            screen,
-            true,
-        );
+    let right_eye = Matrix::perspective_stereo_tilt(
+        fov_y,
+        AspectRatio::TopScreen,
+        near,
+        far,
+        iod,
+        screen,
+        CoordinateSystem::LeftHanded,
+    );
 
-        citro3d_sys::Mtx_PerspTilt(
-            center.as_mut_ptr(),
-            fovy,
-            citro3d_sys::C3D_AspectRatioBot as f32,
-            near,
-            far,
-            true,
-        );
+    let center = Matrix::perspective_tilt(
+        fov_y,
+        AspectRatio::BottomScreen,
+        near,
+        far,
+        CoordinateSystem::LeftHanded,
+    );
 
-        Projections {
-            left: left_eye.assume_init(),
-            right: right_eye.assume_init(),
-            center: center.assume_init(),
-        }
+    Projections {
+        left: left_eye,
+        right: right_eye,
+        center,
     }
 }
 
-fn scene_init(program: &mut shader::Program) -> i8 {
+fn scene_init(program: &mut shader::Program) {
     // Load the vertex shader, create a shader program and bind it
     unsafe {
-        citro3d_sys::C3D_BindProgram(program.as_raw());
+        citro3d_sys::C3D_BindProgram(program.as_raw_mut());
 
         // Configure the first fragment shading substage to just pass through the vertex color
         // See https://www.opengl.org/sdk/docs/man2/xhtml/glTexEnv.xml for more insight
@@ -242,13 +226,5 @@ fn scene_init(program: &mut shader::Program) -> i8 {
             0,
         );
         citro3d_sys::C3D_TexEnvFunc(env, citro3d_sys::C3D_Both, ctru_sys::GPU_REPLACE);
-
-        // Get the location of the uniforms
-        let projection_name = CStr::from_bytes_with_nul(b"projection\0").unwrap();
-
-        ctru_sys::shaderInstanceGetUniformLocation(
-            (*program.as_raw()).vertexShader,
-            projection_name.as_ptr(),
-        )
     }
 }

--- a/citro3d/src/buffer.rs
+++ b/citro3d/src/buffer.rs
@@ -100,7 +100,6 @@ impl Info {
     ///
     /// * if `vbo_data` is not allocated with the [`ctru::linear`] allocator
     /// * if the maximum number (12) of VBOs are already registered
-    ///
     pub fn add<'this, 'vbo, 'idx, T>(
         &'this mut self,
         vbo_data: &'vbo [T],

--- a/citro3d/src/error.rs
+++ b/citro3d/src/error.rs
@@ -1,5 +1,6 @@
 //! General-purpose error and result types returned by public APIs of this crate.
 
+use std::ffi::NulError;
 use std::num::TryFromIntError;
 use std::sync::TryLockError;
 
@@ -31,6 +32,10 @@ pub enum Error {
     /// The given memory could not be converted to a physical address for sharing
     /// with the GPU. Data should be allocated with [`ctru::linear`].
     InvalidMemoryLocation,
+    /// The given name was not valid for the requested purpose.
+    InvalidName,
+    /// The requested resource could not be found.
+    NotFound,
 }
 
 impl From<TryFromIntError> for Error {
@@ -42,5 +47,11 @@ impl From<TryFromIntError> for Error {
 impl<T> From<TryLockError<T>> for Error {
     fn from(_: TryLockError<T>) -> Self {
         Self::LockHeld
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(_: NulError) -> Self {
+        Self::InvalidName
     }
 }

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -11,7 +11,6 @@ pub mod shader;
 pub mod uniform;
 
 pub use error::{Error, Result};
-pub use math::Matrix;
 
 use self::uniform::Uniform;
 
@@ -132,7 +131,8 @@ impl Instance {
     ///
     /// ```
     /// # let _runner = test_runner::GdbRunner::default();
-    /// # use citro3d::{uniform, Matrix};
+    /// # use citro3d::uniform;
+    /// # use citro3d::math::Matrix;
     /// #
     /// # let mut instance = citro3d::Instance::new().unwrap();
     /// let idx = uniform::Index::from(0);
@@ -149,7 +149,8 @@ impl Instance {
     ///
     /// ```
     /// # let _runner = test_runner::GdbRunner::default();
-    /// # use citro3d::{uniform, Matrix};
+    /// # use citro3d::uniform;
+    /// # use citro3d::math::Matrix;
     /// #
     /// # let mut instance = citro3d::Instance::new().unwrap();
     /// let idx = uniform::Index::from(0);

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -126,11 +126,37 @@ impl Instance {
         }
     }
 
-    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: &impl Uniform) {
+    /// Bind a uniform to the given `index` in the vertex shader for the next draw call.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use citro3d::{uniform, Matrix};
+    /// #
+    /// # let mut instance = citro3d::Instance::new().unwrap();
+    /// let idx = uniform::Index::from(0);
+    /// let mtx = Matrix::identity();
+    /// instance.bind_vertex_uniform(idx, &mtx);
+    /// ```
+    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Uniform) {
         uniform.bind(self, shader::Type::Vertex, index);
     }
 
-    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: &impl Uniform) {
+    /// Bind a uniform to the given `index` in the geometry shader for the next draw call.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use citro3d::{uniform, Matrix};
+    /// #
+    /// # let mut instance = citro3d::Instance::new().unwrap();
+    /// let idx = uniform::Index::from(0);
+    /// let mtx = Matrix::identity();
+    /// instance.bind_geometry_uniform(idx, &mtx);
+    /// ```
+    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Uniform) {
         uniform.bind(self, shader::Type::Geometry, index);
     }
 }
@@ -139,24 +165,6 @@ impl Drop for Instance {
     fn drop(&mut self) {
         unsafe {
             citro3d_sys::C3D_Fini();
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-#[non_exhaustive]
-pub enum AspectRatio {
-    TopScreen,
-    BottomScreen,
-    Other(f32),
-}
-
-impl From<AspectRatio> for f32 {
-    fn from(ratio: AspectRatio) -> Self {
-        match ratio {
-            AspectRatio::TopScreen => citro3d_sys::C3D_AspectRatioTop as f32,
-            AspectRatio::BottomScreen => citro3d_sys::C3D_AspectRatioBot as f32,
-            AspectRatio::Other(ratio) => ratio,
         }
     }
 }

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -8,9 +8,12 @@ pub mod error;
 pub mod math;
 pub mod render;
 pub mod shader;
+pub mod uniform;
 
 pub use error::{Error, Result};
 pub use math::Matrix;
+
+use self::uniform::Uniform;
 
 pub mod macros {
     //! Helper macros for working with shaders.
@@ -123,17 +126,12 @@ impl Instance {
         }
     }
 
-    // TODO: need separate versions for vertex/geometry and different dimensions?
-    // Maybe we could do something nicer with const generics, or something, although
-    // it will probably be tricker
-    pub fn update_vertex_uniform_mat4x4(&mut self, index: i8, matrix: &Matrix) {
-        unsafe {
-            citro3d_sys::C3D_FVUnifMtx4x4(
-                ctru_sys::GPU_VERTEX_SHADER,
-                index.into(),
-                matrix.as_raw(),
-            )
-        }
+    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: &impl Uniform) {
+        uniform.bind(self, shader::Type::Vertex, index);
+    }
+
+    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: &impl Uniform) {
+        uniform.bind(self, shader::Type::Geometry, index);
     }
 }
 

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -1,0 +1,87 @@
+//! Safe wrappers for working with matrix and vector types provided by `citro3d`.
+
+use std::mem::MaybeUninit;
+
+use crate::AspectRatio;
+
+/// A 4-vector of [`u8`]s.
+pub struct IntVec(citro3d_sys::C3D_IVec);
+
+/// A 4-vector of [`f32`]s.
+pub struct FloatVec(citro3d_sys::C3D_FVec);
+
+/// A quaternion, internally represented the same way as [`FVec`].
+pub struct Quaternion(citro3d_sys::C3D_FQuat);
+
+/// A 4x4 row-major matrix of [`f32`]s.
+pub struct Matrix(citro3d_sys::C3D_Mtx);
+
+/// Whether to use left-handed or right-handed coordinates for calculations.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive] // This probably is exhaustive, but just in case
+pub enum CoordinateSystem {
+    LeftHanded,
+    RightHanded,
+}
+
+impl Matrix {
+    // TODO: this could probably be generalized with something like builder or options
+    // pattern. Should look and see what the different citro3d implementations look like
+    pub fn perspective_stereo_tilt(
+        fov_y: f32,
+        aspect_ratio: AspectRatio,
+        near: f32,
+        far: f32,
+        interocular_distance: f32,
+        /* better name ?? */ screen_depth: f32,
+        coordinates: CoordinateSystem,
+    ) -> Self {
+        let mut result = MaybeUninit::uninit();
+
+        let inner = unsafe {
+            citro3d_sys::Mtx_PerspStereoTilt(
+                result.as_mut_ptr(),
+                fov_y,
+                aspect_ratio.into(),
+                near,
+                far,
+                interocular_distance,
+                screen_depth,
+                matches!(coordinates, CoordinateSystem::LeftHanded),
+            );
+
+            result.assume_init()
+        };
+
+        Self(inner)
+    }
+
+    pub fn perspective_tilt(
+        fov_y: f32,
+        aspect_ratio: AspectRatio,
+        near: f32,
+        far: f32,
+        coordinates: CoordinateSystem,
+    ) -> Self {
+        let mut result = MaybeUninit::uninit();
+
+        let inner = unsafe {
+            citro3d_sys::Mtx_PerspTilt(
+                result.as_mut_ptr(),
+                fov_y,
+                aspect_ratio.into(),
+                near,
+                far,
+                matches!(coordinates, CoordinateSystem::LeftHanded),
+            );
+
+            result.assume_init()
+        };
+
+        Self(inner)
+    }
+
+    pub(crate) fn as_raw(&self) -> *const citro3d_sys::C3D_Mtx {
+        &self.0
+    }
+}

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -16,67 +16,61 @@ pub struct Quaternion(citro3d_sys::C3D_FQuat);
 /// A 4x4 row-major matrix of `f32`s.
 pub struct Matrix(citro3d_sys::C3D_Mtx);
 
-/// Whether to use left-handed or right-handed coordinates for calculations.
-#[derive(Clone, Copy, Debug)]
-#[non_exhaustive] // This probably is exhaustive, but just in case
-pub enum CoordinateSystem {
-    LeftHanded,
-    RightHanded,
-}
-
 impl Matrix {
-    // TODO: this could probably be generalized with something like builder or options
-    // pattern. Should look and see what the different citro3d implementations look like
-    pub fn perspective_stereo_tilt(
-        fov_y: f32,
+    // TODO: does it make sense to have a helper that builds both left and right
+    // eyes for stereoscopic at the same time?
+
+    /// Construct a projection matrix suitable for projecting 3D world space onto
+    /// the 3DS screens.
+    pub fn perspective_projection(
+        vertical_fov: f32,
         aspect_ratio: AspectRatio,
-        near: f32,
-        far: f32,
-        interocular_distance: f32,
-        /* better name ?? */ screen_depth: f32,
+        orientation: Orientation,
+        clip_plane: ClipPlane,
+        stereo: Stereoscopic,
         coordinates: CoordinateSystem,
     ) -> Self {
-        let mut result = MaybeUninit::uninit();
+        let (make_mtx_persp, make_mtx_stereo);
 
-        let inner = unsafe {
-            citro3d_sys::Mtx_PerspStereoTilt(
-                result.as_mut_ptr(),
-                fov_y,
-                aspect_ratio.into(),
-                near,
-                far,
+        let initialize_mtx: &dyn Fn(_, _, _, _, _, _) -> _ = match stereo {
+            Stereoscopic::Mono => {
+                let make_mtx = match orientation {
+                    Orientation::Natural => citro3d_sys::Mtx_PerspTilt,
+                    Orientation::HardwareDefault => citro3d_sys::Mtx_Persp,
+                };
+
+                make_mtx_persp = move |a, b, c, d, e, f| unsafe { make_mtx(a, b, c, d, e, f) };
+                &make_mtx_persp
+            }
+            Stereoscopic::Stereo {
                 interocular_distance,
                 screen_depth,
-                matches!(coordinates, CoordinateSystem::LeftHanded),
-            );
+            } => {
+                let make_mtx = match orientation {
+                    Orientation::Natural => citro3d_sys::Mtx_PerspStereoTilt,
+                    Orientation::HardwareDefault => citro3d_sys::Mtx_PerspStereo,
+                };
 
-            result.assume_init()
+                make_mtx_stereo = move |a, b, c, d, e, f| unsafe {
+                    make_mtx(a, b, c, d, interocular_distance, screen_depth, e, f)
+                };
+                &make_mtx_stereo
+            }
         };
 
-        Self(inner)
-    }
+        let left_handed = matches!(coordinates, CoordinateSystem::LeftHanded);
 
-    pub fn perspective_tilt(
-        fov_y: f32,
-        aspect_ratio: AspectRatio,
-        near: f32,
-        far: f32,
-        coordinates: CoordinateSystem,
-    ) -> Self {
         let mut result = MaybeUninit::uninit();
+        initialize_mtx(
+            result.as_mut_ptr(),
+            vertical_fov,
+            aspect_ratio.into(),
+            clip_plane.near,
+            clip_plane.far,
+            left_handed,
+        );
 
-        let inner = unsafe {
-            citro3d_sys::Mtx_PerspTilt(
-                result.as_mut_ptr(),
-                fov_y,
-                aspect_ratio.into(),
-                near,
-                far,
-                matches!(coordinates, CoordinateSystem::LeftHanded),
-            );
-
-            result.assume_init()
-        };
+        let inner = unsafe { result.assume_init() };
 
         Self(inner)
     }
@@ -84,4 +78,57 @@ impl Matrix {
     pub(crate) fn as_raw(&self) -> *const citro3d_sys::C3D_Mtx {
         &self.0
     }
+}
+
+/// Whether to use left-handed or right-handed coordinates for calculations.
+#[derive(Clone, Copy, Debug)]
+pub enum CoordinateSystem {
+    LeftHanded,
+    RightHanded,
+}
+
+/// Whether to rotate a projection to account for the 3DS screen configuration.
+/// Both screens on the 3DS are oriented such that the "top" of the screen is
+/// on the [left | right] ? side of the device when it's held normally, so
+/// projections must account for this extra rotation to display in the correct
+/// orientation.
+#[derive(Clone, Copy, Debug)]
+pub enum Orientation {
+    /// Rotate the projection 90° to account for the 3DS screen rotation.
+    Natural,
+    /// Don't rotate the projection at all.
+    HardwareDefault,
+}
+
+#[derive(Clone, Copy, Debug)]
+// TODO: better name
+pub enum Stereoscopic {
+    Mono,
+    Stereo {
+        interocular_distance: f32,
+        // TODO: better name? At least docstring
+        screen_depth: f32,
+    },
+}
+
+impl Stereoscopic {
+    /// Flip the stereoscopic projection for the opposite eye.
+    pub fn invert(self) -> Self {
+        match self {
+            Self::Stereo {
+                interocular_distance,
+                screen_depth,
+            } => Self::Stereo {
+                interocular_distance: -interocular_distance,
+                screen_depth,
+            },
+            mono => mono,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClipPlane {
+    pub near: f32,
+    pub far: f32,
 }

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -2,6 +2,10 @@
 
 use std::mem::MaybeUninit;
 
+mod projection;
+
+pub use projection::{Orthographic, Perspective, Projection};
+
 /// A 4-vector of `u8`s.
 #[doc(alias = "C3D_IVec")]
 pub struct IVec(citro3d_sys::C3D_IVec);
@@ -19,6 +23,17 @@ pub struct FQuat(citro3d_sys::C3D_FQuat);
 pub struct Matrix(citro3d_sys::C3D_Mtx);
 
 impl Matrix {
+    /// Construct the zero matrix.
+    #[doc(alias = "Mtx_Zeros")]
+    pub fn zero() -> Self {
+        // TODO: should this also be Default::default()?
+        let mut out = MaybeUninit::uninit();
+        unsafe {
+            citro3d_sys::Mtx_Zeros(out.as_mut_ptr());
+            Self(out.assume_init())
+        }
+    }
+
     /// Construct the identity matrix.
     #[doc(alias = "Mtx_Identity")]
     pub fn identity() -> Self {
@@ -29,165 +44,42 @@ impl Matrix {
         }
     }
 
-    /// Construct a projection matrix suitable for projecting 3D world space onto
-    /// the 3DS screens.
-    ///
-    /// # Parameters
-    ///
-    /// * `vertical_fov_radians`: the vertical field of view, measured in radians
-    /// * `aspect_ratio`: The aspect ratio of the projection
-    /// * `orientation`: the orientation of the projection with respect to the screen
-    /// * `coordinates`: the handedness of the coordinate system to use
-    /// * `stereo`: if specified, the offset to displace the projection by
-    ///     for stereoscopic rendering.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use citro3d::math::*;
-    /// # use std::f32::consts::PI;
-    /// #
-    /// # let _runner = test_runner::GdbRunner::default();
-    ///
-    /// let clip_planes = ClipPlanes {
-    ///     near: 0.01,
-    ///     far: 100.0,
-    /// };
-    ///
-    /// let center = Matrix::perspective_projection(
-    ///     PI / 4.0,
-    ///     AspectRatio::BottomScreen,
-    ///     ScreenOrientation::Rotated,
-    ///     clip_planes,
-    ///     CoordinateOrientation::LeftHanded,
-    ///     None,
-    /// );
-    ///
-    /// let right_eye = Matrix::perspective_projection(
-    ///     PI / 4.0,
-    ///     AspectRatio::BottomScreen,
-    ///     ScreenOrientation::Rotated,
-    ///     clip_planes,
-    ///     CoordinateOrientation::LeftHanded,
-    ///     Some(StereoDisplacement {
-    ///         displacement: 1.0,
-    ///         screen_depth: 2.0,
-    ///     }),
-    /// );
-    /// ```
-    #[doc(alias = "Mtx_Persp")]
-    #[doc(alias = "Mtx_PerspTilt")]
-    pub fn perspective_projection(
-        vertical_fov_radians: f32,
-        aspect_ratio: AspectRatio,
-        orientation: ScreenOrientation,
-        clip_plane: ClipPlanes,
-        coordinates: CoordinateOrientation,
-        stereo: Option<StereoDisplacement>,
-    ) -> Self {
-        let mut result = MaybeUninit::uninit();
-
-        let left_handed = matches!(coordinates, CoordinateOrientation::LeftHanded);
-
-        if let Some(stereo) = stereo {
-            let initialize_mtx = orientation.perpsective_stereo_builder();
-            unsafe {
-                initialize_mtx(
-                    result.as_mut_ptr(),
-                    vertical_fov_radians,
-                    aspect_ratio.into(),
-                    clip_plane.near,
-                    clip_plane.far,
-                    stereo.displacement,
-                    stereo.screen_depth,
-                    left_handed,
-                );
-            }
-        } else {
-            let initialize_mtx = orientation.perspective_mono_builder();
-            unsafe {
-                initialize_mtx(
-                    result.as_mut_ptr(),
-                    vertical_fov_radians,
-                    aspect_ratio.into(),
-                    clip_plane.near,
-                    clip_plane.far,
-                    left_handed,
-                );
-            }
-        }
-
-        let inner = unsafe { result.assume_init() };
-
-        Self(inner)
-    }
-
-    /// Helper function to build both eyes' perspective projection matrices
-    /// at once. See [`perspective_projection`] for a description of each
-    /// parameter.
-    ///
-    /// ```
-    /// # use std::f32::consts::PI;
-    /// # use citro3d::math::*;
-    /// #
-    /// # let _runner = test_runner::GdbRunner::default();
-    ///
-    /// let (left_eye, right_eye) = Matrix::stereo_projections(
-    ///     PI / 4.0,
-    ///     AspectRatio::TopScreen,
-    ///     ScreenOrientation::Rotated,
-    ///     ClipPlanes {
-    ///         near: 0.01,
-    ///         far: 100.0,
-    ///     },
-    ///     CoordinateOrientation::LeftHanded,
-    ///     StereoDisplacement::new(0.5, 2.0),
-    /// );
-    /// ```
-    ///
-    /// [`perspective_projection`]: Self::perspective_projection
-    #[doc(alias = "Mtx_PerspStereo")]
-    #[doc(alias = "Mtx_PerspStereoTilt")]
-    pub fn stereo_projections(
-        vertical_fov_radians: f32,
-        aspect_ratio: AspectRatio,
-        orientation: ScreenOrientation,
-        clip_plane: ClipPlanes,
-        coordinates: CoordinateOrientation,
-        (left_eye, right_eye): (StereoDisplacement, StereoDisplacement),
-    ) -> (Self, Self) {
-        let left = Self::perspective_projection(
-            vertical_fov_radians,
-            aspect_ratio,
-            orientation,
-            clip_plane,
-            coordinates,
-            Some(left_eye),
-        );
-        let right = Self::perspective_projection(
-            vertical_fov_radians,
-            aspect_ratio,
-            orientation,
-            clip_plane,
-            coordinates,
-            Some(right_eye),
-        );
-        (left, right)
-    }
-
     pub(crate) fn as_raw(&self) -> *const citro3d_sys::C3D_Mtx {
         &self.0
     }
 }
 
+// region: Projection configuration
+//
+// TODO: maybe move into `mod projection`, or hoist `projection::*` into here.
+// it will probably mostly depend on how big all the matrices/vec impls get.
+// Also worth considering is whether `mod projection` should be pub.
+
 /// The [orientation](https://en.wikipedia.org/wiki/Orientation_(geometry))
-/// (or "handedness") of the coordinate system.
+/// (or "handedness") of the coordinate system. Coordinates are always +Y-up,
+/// +X-right.
 #[derive(Clone, Copy, Debug)]
 pub enum CoordinateOrientation {
-    /// A left-handed coordinate system.
+    /// A left-handed coordinate system. +Z points into the screen.
     LeftHanded,
-    /// A right-handed coordinate system.
+    /// A right-handed coordinate system. +Z points out of the screen.
     RightHanded,
+}
+
+impl CoordinateOrientation {
+    pub(crate) fn is_left_handed(self) -> bool {
+        matches!(self, Self::LeftHanded)
+    }
+}
+
+impl Default for CoordinateOrientation {
+    /// This is an opinionated default, but [`RightHanded`](Self::RightHanded)
+    /// seems to be the preferred coordinate system for most
+    /// [examples](https://github.com/devkitPro/3ds-examples)
+    /// from upstream, and is also fairly common in other applications.
+    fn default() -> Self {
+        Self::RightHanded
+    }
 }
 
 /// Whether to rotate a projection to account for the 3DS screen orientation.
@@ -203,37 +95,14 @@ pub enum ScreenOrientation {
     None,
 }
 
-impl ScreenOrientation {
-    fn perspective_mono_builder(
-        self,
-    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, bool) {
-        match self {
-            Self::Rotated => citro3d_sys::Mtx_PerspTilt,
-            Self::None => citro3d_sys::Mtx_Persp,
-        }
-    }
-
-    fn perpsective_stereo_builder(
-        self,
-    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, f32, f32, bool) {
-        match self {
-            Self::Rotated => citro3d_sys::Mtx_PerspStereoTilt,
-            Self::None => citro3d_sys::Mtx_PerspStereo,
-        }
-    }
-
-    // TODO: orthographic projections
-    fn ortho_builder(
-        self,
-    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, f32, f32, bool) {
-        match self {
-            Self::Rotated => citro3d_sys::Mtx_OrthoTilt,
-            Self::None => citro3d_sys::Mtx_Ortho,
-        }
+impl Default for ScreenOrientation {
+    fn default() -> Self {
+        Self::Rotated
     }
 }
 
 /// Configuration for calculating stereoscopic projections.
+// TODO: not totally happy with this name + API yet, but it works for now.
 #[derive(Clone, Copy, Debug)]
 pub struct StereoDisplacement {
     /// The horizontal offset of the eye from center. Negative values
@@ -269,13 +138,23 @@ impl StereoDisplacement {
     }
 }
 
-/// Configuration for the [frustum](https://en.wikipedia.org/wiki/Viewing_frustum)
-/// of a perspective projection.
+/// Configuration for the clipping planes of a projection.
+///
+/// For [`Perspective`] projections, this is used for the near and far clip planes
+/// of the [view frustum](https://en.wikipedia.org/wiki/Viewing_frustum).
+///
+/// For [`Orthographic`] projections, this is used for the Z clipping planes of
+/// the projection.
+///
+/// Note that the `near` value should always be less than `far`, regardless of
+/// [`CoordinateOrientation`]. In other words, these values will be negated
+/// when used with a [`RightHanded`](CoordinateOrientation::RightHanded)
+/// orientation.
 #[derive(Clone, Copy, Debug)]
 pub struct ClipPlanes {
-    /// The z-depth of the near clip plane.
+    /// The Z-depth of the near clip plane, usually close or equal to zero.
     pub near: f32,
-    /// The z-depth of the far clip plane.
+    /// The Z-depth of the far clip plane, usually greater than zero.
     pub far: f32,
 }
 
@@ -302,3 +181,5 @@ impl From<AspectRatio> for f32 {
         }
     }
 }
+
+// endregion

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -2,77 +2,177 @@
 
 use std::mem::MaybeUninit;
 
-use crate::AspectRatio;
-
 /// A 4-vector of `u8`s.
-pub struct IntVec(citro3d_sys::C3D_IVec);
+#[doc(alias = "C3D_IVec")]
+pub struct IVec(citro3d_sys::C3D_IVec);
 
 /// A 4-vector of `f32`s.
-pub struct FloatVec(citro3d_sys::C3D_FVec);
+#[doc(alias = "C3D_FVec")]
+pub struct FVec(citro3d_sys::C3D_FVec);
 
-/// A quaternion, internally represented the same way as [`FloatVec`].
-pub struct Quaternion(citro3d_sys::C3D_FQuat);
+/// A quaternion, internally represented the same way as [`FVec`].
+#[doc(alias = "C3D_FQuat")]
+pub struct FQuat(citro3d_sys::C3D_FQuat);
 
 /// A 4x4 row-major matrix of `f32`s.
+#[doc(alias = "C3D_Mtx")]
 pub struct Matrix(citro3d_sys::C3D_Mtx);
 
 impl Matrix {
-    // TODO: does it make sense to have a helper that builds both left and right
-    // eyes for stereoscopic at the same time?
+    /// Construct the identity matrix.
+    #[doc(alias = "Mtx_Identity")]
+    pub fn identity() -> Self {
+        let mut out = MaybeUninit::uninit();
+        unsafe {
+            citro3d_sys::Mtx_Identity(out.as_mut_ptr());
+            Self(out.assume_init())
+        }
+    }
 
     /// Construct a projection matrix suitable for projecting 3D world space onto
     /// the 3DS screens.
+    ///
+    /// # Parameters
+    ///
+    /// * `vertical_fov_radians`: the vertical field of view, measured in radians
+    /// * `aspect_ratio`: The aspect ratio of the projection
+    /// * `orientation`: the orientation of the projection with respect to the screen
+    /// * `coordinates`: the handedness of the coordinate system to use
+    /// * `stereo`: if specified, the offset to displace the projection by
+    ///     for stereoscopic rendering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use citro3d::math::*;
+    /// # use std::f32::consts::PI;
+    /// #
+    /// # let _runner = test_runner::GdbRunner::default();
+    ///
+    /// let clip_planes = ClipPlanes {
+    ///     near: 0.01,
+    ///     far: 100.0,
+    /// };
+    ///
+    /// let center = Matrix::perspective_projection(
+    ///     PI / 4.0,
+    ///     AspectRatio::BottomScreen,
+    ///     ScreenOrientation::Rotated,
+    ///     clip_planes,
+    ///     CoordinateOrientation::LeftHanded,
+    ///     None,
+    /// );
+    ///
+    /// let right_eye = Matrix::perspective_projection(
+    ///     PI / 4.0,
+    ///     AspectRatio::BottomScreen,
+    ///     ScreenOrientation::Rotated,
+    ///     clip_planes,
+    ///     CoordinateOrientation::LeftHanded,
+    ///     Some(StereoDisplacement {
+    ///         displacement: 1.0,
+    ///         screen_depth: 2.0,
+    ///     }),
+    /// );
+    /// ```
+    #[doc(alias = "Mtx_Persp")]
+    #[doc(alias = "Mtx_PerspTilt")]
     pub fn perspective_projection(
-        vertical_fov: f32,
+        vertical_fov_radians: f32,
         aspect_ratio: AspectRatio,
-        orientation: Orientation,
-        clip_plane: ClipPlane,
-        stereo: Stereoscopic,
-        coordinates: CoordinateSystem,
+        orientation: ScreenOrientation,
+        clip_plane: ClipPlanes,
+        coordinates: CoordinateOrientation,
+        stereo: Option<StereoDisplacement>,
     ) -> Self {
-        let (make_mtx_persp, make_mtx_stereo);
-
-        let initialize_mtx: &dyn Fn(_, _, _, _, _, _) -> _ = match stereo {
-            Stereoscopic::Mono => {
-                let make_mtx = match orientation {
-                    Orientation::Natural => citro3d_sys::Mtx_PerspTilt,
-                    Orientation::HardwareDefault => citro3d_sys::Mtx_Persp,
-                };
-
-                make_mtx_persp = move |a, b, c, d, e, f| unsafe { make_mtx(a, b, c, d, e, f) };
-                &make_mtx_persp
-            }
-            Stereoscopic::Stereo {
-                interocular_distance,
-                screen_depth,
-            } => {
-                let make_mtx = match orientation {
-                    Orientation::Natural => citro3d_sys::Mtx_PerspStereoTilt,
-                    Orientation::HardwareDefault => citro3d_sys::Mtx_PerspStereo,
-                };
-
-                make_mtx_stereo = move |a, b, c, d, e, f| unsafe {
-                    make_mtx(a, b, c, d, interocular_distance, screen_depth, e, f)
-                };
-                &make_mtx_stereo
-            }
-        };
-
-        let left_handed = matches!(coordinates, CoordinateSystem::LeftHanded);
-
         let mut result = MaybeUninit::uninit();
-        initialize_mtx(
-            result.as_mut_ptr(),
-            vertical_fov,
-            aspect_ratio.into(),
-            clip_plane.near,
-            clip_plane.far,
-            left_handed,
-        );
+
+        let left_handed = matches!(coordinates, CoordinateOrientation::LeftHanded);
+
+        if let Some(stereo) = stereo {
+            let initialize_mtx = orientation.perpsective_stereo_builder();
+            unsafe {
+                initialize_mtx(
+                    result.as_mut_ptr(),
+                    vertical_fov_radians,
+                    aspect_ratio.into(),
+                    clip_plane.near,
+                    clip_plane.far,
+                    stereo.displacement,
+                    stereo.screen_depth,
+                    left_handed,
+                );
+            }
+        } else {
+            let initialize_mtx = orientation.perspective_mono_builder();
+            unsafe {
+                initialize_mtx(
+                    result.as_mut_ptr(),
+                    vertical_fov_radians,
+                    aspect_ratio.into(),
+                    clip_plane.near,
+                    clip_plane.far,
+                    left_handed,
+                );
+            }
+        }
 
         let inner = unsafe { result.assume_init() };
 
         Self(inner)
+    }
+
+    /// Helper function to build both eyes' perspective projection matrices
+    /// at once. See [`perspective_projection`] for a description of each
+    /// parameter.
+    ///
+    /// ```
+    /// # use std::f32::consts::PI;
+    /// # use citro3d::math::*;
+    /// #
+    /// # let _runner = test_runner::GdbRunner::default();
+    ///
+    /// let (left_eye, right_eye) = Matrix::stereo_projections(
+    ///     PI / 4.0,
+    ///     AspectRatio::TopScreen,
+    ///     ScreenOrientation::Rotated,
+    ///     ClipPlanes {
+    ///         near: 0.01,
+    ///         far: 100.0,
+    ///     },
+    ///     CoordinateOrientation::LeftHanded,
+    ///     StereoDisplacement::new(0.5, 2.0),
+    /// );
+    /// ```
+    ///
+    /// [`perspective_projection`]: Self::perspective_projection
+    #[doc(alias = "Mtx_PerspStereo")]
+    #[doc(alias = "Mtx_PerspStereoTilt")]
+    pub fn stereo_projections(
+        vertical_fov_radians: f32,
+        aspect_ratio: AspectRatio,
+        orientation: ScreenOrientation,
+        clip_plane: ClipPlanes,
+        coordinates: CoordinateOrientation,
+        (left_eye, right_eye): (StereoDisplacement, StereoDisplacement),
+    ) -> (Self, Self) {
+        let left = Self::perspective_projection(
+            vertical_fov_radians,
+            aspect_ratio,
+            orientation,
+            clip_plane,
+            coordinates,
+            Some(left_eye),
+        );
+        let right = Self::perspective_projection(
+            vertical_fov_radians,
+            aspect_ratio,
+            orientation,
+            clip_plane,
+            coordinates,
+            Some(right_eye),
+        );
+        (left, right)
     }
 
     pub(crate) fn as_raw(&self) -> *const citro3d_sys::C3D_Mtx {
@@ -80,55 +180,125 @@ impl Matrix {
     }
 }
 
-/// Whether to use left-handed or right-handed coordinates for calculations.
+/// The [orientation](https://en.wikipedia.org/wiki/Orientation_(geometry))
+/// (or "handedness") of the coordinate system.
 #[derive(Clone, Copy, Debug)]
-pub enum CoordinateSystem {
+pub enum CoordinateOrientation {
+    /// A left-handed coordinate system.
     LeftHanded,
+    /// A right-handed coordinate system.
     RightHanded,
 }
 
-/// Whether to rotate a projection to account for the 3DS screen configuration.
-/// Both screens on the 3DS are oriented such that the "top" of the screen is
-/// on the [left | right] ? side of the device when it's held normally, so
-/// projections must account for this extra rotation to display in the correct
-/// orientation.
+/// Whether to rotate a projection to account for the 3DS screen orientation.
+/// Both screens on the 3DS are oriented such that the "top-left" of the screen
+/// in framebuffer coordinates is the physical bottom-left of the screen
+/// (i.e. the "width" is smaller than the "height").
 #[derive(Clone, Copy, Debug)]
-pub enum Orientation {
-    /// Rotate the projection 90° to account for the 3DS screen rotation.
-    Natural,
-    /// Don't rotate the projection at all.
-    HardwareDefault,
+pub enum ScreenOrientation {
+    /// Rotate 90° clockwise to account for the 3DS screen rotation. Most
+    /// applications will use this variant.
+    Rotated,
+    /// Do not apply any extra rotation to the projection.
+    None,
 }
 
-#[derive(Clone, Copy, Debug)]
-// TODO: better name
-pub enum Stereoscopic {
-    Mono,
-    Stereo {
-        interocular_distance: f32,
-        // TODO: better name? At least docstring
-        screen_depth: f32,
-    },
-}
-
-impl Stereoscopic {
-    /// Flip the stereoscopic projection for the opposite eye.
-    pub fn invert(self) -> Self {
+impl ScreenOrientation {
+    fn perspective_mono_builder(
+        self,
+    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, bool) {
         match self {
-            Self::Stereo {
-                interocular_distance,
-                screen_depth,
-            } => Self::Stereo {
-                interocular_distance: -interocular_distance,
-                screen_depth,
-            },
-            mono => mono,
+            Self::Rotated => citro3d_sys::Mtx_PerspTilt,
+            Self::None => citro3d_sys::Mtx_Persp,
+        }
+    }
+
+    fn perpsective_stereo_builder(
+        self,
+    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, f32, f32, bool) {
+        match self {
+            Self::Rotated => citro3d_sys::Mtx_PerspStereoTilt,
+            Self::None => citro3d_sys::Mtx_PerspStereo,
+        }
+    }
+
+    // TODO: orthographic projections
+    fn ortho_builder(
+        self,
+    ) -> unsafe extern "C" fn(*mut citro3d_sys::C3D_Mtx, f32, f32, f32, f32, f32, f32, bool) {
+        match self {
+            Self::Rotated => citro3d_sys::Mtx_OrthoTilt,
+            Self::None => citro3d_sys::Mtx_Ortho,
         }
     }
 }
 
+/// Configuration for calculating stereoscopic projections.
 #[derive(Clone, Copy, Debug)]
-pub struct ClipPlane {
+pub struct StereoDisplacement {
+    /// The horizontal offset of the eye from center. Negative values
+    /// correspond to the left eye, and positive values to the right eye.
+    pub displacement: f32,
+    /// The position of the screen, which determines the focal length. Objects
+    /// closer than this depth will appear to pop out of the screen, and objects
+    /// further than this will appear inside the screen.
+    pub screen_depth: f32,
+}
+
+impl StereoDisplacement {
+    /// Construct displacement for the left and right eyes simulataneously.
+    /// The given `interocular_distance` describes the distance between the two
+    /// rendered "eyes". A negative value will be treated the same as a positive
+    /// value of the same magnitude.
+    ///
+    /// See struct documentation for details about the
+    /// [`screen_depth`](Self::screen_depth) parameter.
+    pub fn new(interocular_distance: f32, screen_depth: f32) -> (Self, Self) {
+        let displacement = interocular_distance.abs() / 2.0;
+
+        let left_eye = Self {
+            displacement: -displacement,
+            screen_depth,
+        };
+        let right_eye = Self {
+            displacement,
+            screen_depth,
+        };
+
+        (left_eye, right_eye)
+    }
+}
+
+/// Configuration for the [frustum](https://en.wikipedia.org/wiki/Viewing_frustum)
+/// of a perspective projection.
+#[derive(Clone, Copy, Debug)]
+pub struct ClipPlanes {
+    /// The z-depth of the near clip plane.
     pub near: f32,
+    /// The z-depth of the far clip plane.
     pub far: f32,
+}
+
+/// The aspect ratio of a projection plane.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum AspectRatio {
+    /// The aspect ratio of the 3DS' top screen (per-eye).
+    #[doc(alias = "C3D_AspectRatioTop")]
+    TopScreen,
+    /// The aspect ratio of the 3DS' bottom screen.
+    #[doc(alias = "C3D_AspectRatioBot")]
+    BottomScreen,
+    /// A custom aspect ratio (should be calcualted as `width / height`).
+    Other(f32),
+}
+
+impl From<AspectRatio> for f32 {
+    fn from(ratio: AspectRatio) -> Self {
+        match ratio {
+            AspectRatio::TopScreen => citro3d_sys::C3D_AspectRatioTop as f32,
+            AspectRatio::BottomScreen => citro3d_sys::C3D_AspectRatioBot as f32,
+            AspectRatio::Other(ratio) => ratio,
+        }
+    }
 }

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -4,16 +4,16 @@ use std::mem::MaybeUninit;
 
 use crate::AspectRatio;
 
-/// A 4-vector of [`u8`]s.
+/// A 4-vector of `u8`s.
 pub struct IntVec(citro3d_sys::C3D_IVec);
 
-/// A 4-vector of [`f32`]s.
+/// A 4-vector of `f32`s.
 pub struct FloatVec(citro3d_sys::C3D_FVec);
 
-/// A quaternion, internally represented the same way as [`FVec`].
+/// A quaternion, internally represented the same way as [`FloatVec`].
 pub struct Quaternion(citro3d_sys::C3D_FQuat);
 
-/// A 4x4 row-major matrix of [`f32`]s.
+/// A 4x4 row-major matrix of `f32`s.
 pub struct Matrix(citro3d_sys::C3D_Mtx);
 
 /// Whether to use left-handed or right-handed coordinates for calculations.

--- a/citro3d/src/math/projection.rs
+++ b/citro3d/src/math/projection.rs
@@ -1,0 +1,264 @@
+use std::mem::MaybeUninit;
+use std::ops::Range;
+
+use super::{
+    AspectRatio, ClipPlanes, CoordinateOrientation, Matrix, ScreenOrientation, StereoDisplacement,
+};
+
+/// Configuration for a 3D [projection](https://en.wikipedia.org/wiki/3D_projection).
+/// See specific `Kind` implementations for constructors, e.g.
+/// [`Projection::perspective`] and [`Projection::orthographic`].
+///
+/// To use the resulting projection, convert it to a [`Matrix`] with [`From`]/[`Into`].
+#[derive(Clone, Debug)]
+pub struct Projection<Kind> {
+    coordinates: CoordinateOrientation,
+    rotation: ScreenOrientation,
+    inner: Kind,
+}
+
+impl<Kind> Projection<Kind> {
+    fn new(inner: Kind) -> Self {
+        Self {
+            coordinates: CoordinateOrientation::default(),
+            rotation: ScreenOrientation::default(),
+            inner,
+        }
+    }
+
+    /// Set the coordinate system's orientation for the projection.
+    /// See [`CoordinateOrientation`] for more details.
+    pub fn coordinates(&mut self, orientation: CoordinateOrientation) -> &mut Self {
+        self.coordinates = orientation;
+        self
+    }
+
+    /// Set the screen rotation for the projection.
+    /// See [`ScreenOrientation`] for more details.
+    pub fn screen(&mut self, orientation: ScreenOrientation) -> &mut Self {
+        self.rotation = orientation;
+        self
+    }
+}
+
+/// See [`Projection::perspective`].
+#[derive(Clone, Debug)]
+pub struct Perspective {
+    vertical_fov_radians: f32,
+    aspect_ratio: AspectRatio,
+    clip_planes: ClipPlanes,
+    stereo: Option<StereoDisplacement>,
+}
+
+impl Projection<Perspective> {
+    /// Construct a projection matrix suitable for projecting 3D world space onto
+    /// the 3DS screens.
+    ///
+    /// # Parameters
+    ///
+    /// * `vertical_fov`: the vertical field of view, measured in radians
+    /// * `aspect_ratio`: the aspect ratio of the projection
+    /// * `clip_planes`: the near and far clip planes of the view frustum.
+    ///   [`ClipPlanes`] are always defined by near and far values, regardless
+    ///   of the projection's [`CoordinateOrientation`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use citro3d::math::*;
+    /// # use std::f32::consts::PI;
+    /// #
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// #
+    /// let clip_planes = ClipPlanes {
+    ///     near: 0.01,
+    ///     far: 100.0,
+    /// };
+    ///
+    /// let bottom: Matrix =
+    ///     Projection::perspective(PI / 4.0, AspectRatio::BottomScreen, clip_planes).into();
+    ///
+    /// let top: Matrix = Projection::perspective(PI / 4.0, AspectRatio::TopScreen, clip_planes).into();
+    /// ```
+    #[doc(alias = "Mtx_Persp")]
+    #[doc(alias = "Mtx_PerspTilt")]
+    pub fn perspective(
+        vertical_fov_radians: f32,
+        aspect_ratio: AspectRatio,
+        clip_planes: ClipPlanes,
+    ) -> Self {
+        Self::new(Perspective {
+            vertical_fov_radians,
+            aspect_ratio,
+            clip_planes,
+            stereo: None,
+        })
+    }
+
+    /// Helper function to build both eyes' perspective projection matrices
+    /// at once. See [`StereoDisplacement`] for details on how to configure
+    /// stereoscopy.
+    ///
+    /// ```
+    /// # use std::f32::consts::PI;
+    /// # use citro3d::math::*;
+    /// #
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// #
+    /// let (left, right) = StereoDisplacement::new(0.5, 2.0);
+    /// let (left_eye, right_eye) = Projection::perspective(
+    ///     PI / 4.0,
+    ///     AspectRatio::TopScreen,
+    ///     ClipPlanes {
+    ///         near: 0.01,
+    ///         far: 100.0,
+    ///     },
+    /// )
+    /// .stereo_matrices(left, right);
+    /// ```
+    #[doc(alias = "Mtx_PerspStereo")]
+    #[doc(alias = "Mtx_PerspStereoTilt")]
+    pub fn stereo_matrices(
+        self,
+        left_eye: StereoDisplacement,
+        right_eye: StereoDisplacement,
+    ) -> (Matrix, Matrix) {
+        // TODO: we might be able to avoid this clone if there was a conversion
+        // from &Self to Matrix instead of Self... but it's probably fine for now
+        let left = self.clone().stereo(left_eye);
+        let right = self.stereo(right_eye);
+        // Also, we could consider just returning (Self, Self) here? idk
+        (left.into(), right.into())
+    }
+
+    fn stereo(mut self, displacement: StereoDisplacement) -> Self {
+        self.inner.stereo = Some(displacement);
+        self
+    }
+}
+
+impl From<Projection<Perspective>> for Matrix {
+    fn from(projection: Projection<Perspective>) -> Self {
+        let Perspective {
+            vertical_fov_radians,
+            aspect_ratio,
+            clip_planes,
+            stereo,
+        } = projection.inner;
+
+        let mut result = MaybeUninit::uninit();
+
+        if let Some(stereo) = stereo {
+            let make_mtx = match projection.rotation {
+                ScreenOrientation::Rotated => citro3d_sys::Mtx_PerspStereoTilt,
+                ScreenOrientation::None => citro3d_sys::Mtx_PerspStereo,
+            };
+            unsafe {
+                make_mtx(
+                    result.as_mut_ptr(),
+                    vertical_fov_radians,
+                    aspect_ratio.into(),
+                    clip_planes.near,
+                    clip_planes.far,
+                    stereo.displacement,
+                    stereo.screen_depth,
+                    projection.coordinates.is_left_handed(),
+                );
+            }
+        } else {
+            let make_mtx = match projection.rotation {
+                ScreenOrientation::Rotated => citro3d_sys::Mtx_PerspTilt,
+                ScreenOrientation::None => citro3d_sys::Mtx_Persp,
+            };
+            unsafe {
+                make_mtx(
+                    result.as_mut_ptr(),
+                    vertical_fov_radians,
+                    aspect_ratio.into(),
+                    clip_planes.near,
+                    clip_planes.far,
+                    projection.coordinates.is_left_handed(),
+                );
+            }
+        }
+
+        unsafe { Self(result.assume_init()) }
+    }
+}
+
+/// See [`Projection::orthographic`].
+#[derive(Clone, Debug)]
+pub struct Orthographic {
+    clip_planes_x: Range<f32>,
+    clip_planes_y: Range<f32>,
+    clip_planes_z: ClipPlanes,
+}
+
+impl Projection<Orthographic> {
+    /// Construct an orthographic projection. The X and Y clip planes are passed
+    /// as ranges because their coordinates are always oriented the same way
+    /// (+X right, +Y up).
+    ///
+    /// The Z [`ClipPlanes`], however, are always defined by
+    /// near and far values, regardless of the projection's [`CoordinateOrientation`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use citro3d::math::{Projection, ClipPlanes, Matrix};
+    /// #
+    /// let mtx: Matrix = Projection::orthographic(
+    ///     0.0..240.0,
+    ///     0.0..400.0,
+    ///     ClipPlanes {
+    ///         near: 0.0,
+    ///         far: 100.0,
+    ///     },
+    /// )
+    /// .into();
+    /// ```
+    #[doc(alias = "Mtx_Ortho")]
+    #[doc(alias = "Mtx_OrthoTilt")]
+    pub fn orthographic(
+        clip_planes_x: Range<f32>,
+        clip_planes_y: Range<f32>,
+        clip_planes_z: ClipPlanes,
+    ) -> Self {
+        Self::new(Orthographic {
+            clip_planes_x,
+            clip_planes_y,
+            clip_planes_z,
+        })
+    }
+}
+
+impl From<Projection<Orthographic>> for Matrix {
+    fn from(projection: Projection<Orthographic>) -> Self {
+        let make_mtx = match projection.rotation {
+            ScreenOrientation::Rotated => citro3d_sys::Mtx_OrthoTilt,
+            ScreenOrientation::None => citro3d_sys::Mtx_Ortho,
+        };
+
+        let Orthographic {
+            clip_planes_x,
+            clip_planes_y,
+            clip_planes_z,
+        } = projection.inner;
+
+        let mut out = MaybeUninit::uninit();
+        unsafe {
+            make_mtx(
+                out.as_mut_ptr(),
+                clip_planes_x.start,
+                clip_planes_x.end,
+                clip_planes_y.start,
+                clip_planes_y.end,
+                clip_planes_z.near,
+                clip_planes_z.far,
+                projection.coordinates.is_left_handed(),
+            );
+            Self(out.assume_init())
+        }
+    }
+}

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -67,20 +67,26 @@ impl Program {
         }
     }
 
-    // TODO: newtype for index?
+    /// Get the index of a uniform by name.
+    ///
+    /// # Errors
+    ///
+    /// * If the given `name` contains a null byte
+    /// * If a uniform with the given `name` could not be found
     pub fn get_uniform_location(&self, name: &str) -> crate::Result<i8> {
         let vertex_instance = unsafe { (*self.as_raw()).vertexShader };
-        if vertex_instance.is_null() {
-            return Err(todo!());
-        }
+        assert!(
+            !vertex_instance.is_null(),
+            "vertex shader should never be null!"
+        );
 
-        let name = CString::new(name).map_err(|e| -> crate::Error { todo!() })?;
+        let name = CString::new(name)?;
 
         let idx =
             unsafe { ctru_sys::shaderInstanceGetUniformLocation(vertex_instance, name.as_ptr()) };
 
         if idx < 0 {
-            Err(todo!())
+            Err(crate::Error::NotFound)
         } else {
             Ok(idx)
         }

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -115,7 +115,9 @@ impl Drop for Program {
 /// The type of a shader.
 #[repr(u32)]
 pub enum Type {
+    /// A vertex shader.
     Vertex = ctru_sys::GPU_VERTEX_SHADER,
+    /// A geometry shader.
     Geometry = ctru_sys::GPU_GEOMETRY_SHADER,
 }
 

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -1,5 +1,9 @@
+//! Common definitions for binding uniforms to shaders. This is primarily
+//! done by implementing the [`Uniform`] trait for a given type.
+
 use crate::{shader, Instance, Matrix};
 
+/// The index of a uniform within a [`shader::Program`].
 #[derive(Copy, Clone, Debug)]
 pub struct Index(i8);
 
@@ -19,15 +23,21 @@ mod private {
     use crate::Matrix;
 
     pub trait Sealed {}
-    impl Sealed for Matrix {}
+    impl Sealed for &Matrix {}
 }
 
+/// A shader uniform. This trait is implemented for types that can be bound to
+/// shaders to be used as a uniform input to the shader.
 pub trait Uniform: private::Sealed {
-    fn bind(&self, instance: &mut Instance, shader_type: shader::Type, index: Index);
+    /// Bind the uniform to the given shader index for the given shader type.
+    /// An [`Instance`] is required to prevent concurrent binding of different
+    /// uniforms to the same index.
+    fn bind(self, instance: &mut Instance, shader_type: shader::Type, index: Index);
 }
 
-impl Uniform for Matrix {
-    fn bind(&self, _instance: &mut Instance, type_: shader::Type, index: Index) {
+impl Uniform for &Matrix {
+    #[doc(alias = "C3D_FVUnifMtx4x4")]
+    fn bind(self, _instance: &mut Instance, type_: shader::Type, index: Index) {
         unsafe { citro3d_sys::C3D_FVUnifMtx4x4(type_.into(), index.into(), self.as_raw()) }
     }
 }

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -1,0 +1,33 @@
+use crate::{shader, Instance, Matrix};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Index(i8);
+
+impl From<i8> for Index {
+    fn from(value: i8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Index> for i32 {
+    fn from(value: Index) -> Self {
+        value.0.into()
+    }
+}
+
+mod private {
+    use crate::Matrix;
+
+    pub trait Sealed {}
+    impl Sealed for Matrix {}
+}
+
+pub trait Uniform: private::Sealed {
+    fn bind(&self, instance: &mut Instance, shader_type: shader::Type, index: Index);
+}
+
+impl Uniform for Matrix {
+    fn bind(&self, _instance: &mut Instance, type_: shader::Type, index: Index) {
+        unsafe { citro3d_sys::C3D_FVUnifMtx4x4(type_.into(), index.into(), self.as_raw()) }
+    }
+}

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -1,7 +1,8 @@
 //! Common definitions for binding uniforms to shaders. This is primarily
 //! done by implementing the [`Uniform`] trait for a given type.
 
-use crate::{shader, Instance, Matrix};
+use crate::math::Matrix;
+use crate::{shader, Instance};
 
 /// The index of a uniform within a [`shader::Program`].
 #[derive(Copy, Clone, Debug)]
@@ -20,7 +21,7 @@ impl From<Index> for i32 {
 }
 
 mod private {
-    use crate::Matrix;
+    use crate::math::Matrix;
 
     pub trait Sealed {}
     impl Sealed for &Matrix {}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+unstable_features = true
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
Expose safe wrappers for `Mtx_` APIs, for now mainly just the constructors that are used for projection matrices, since those will probably be the most commonly used. This PR also adds a `Uniform` trait which is how those matrices are bound to a shader to get sent to the GPU, and should also work for other types like `FVec` and possibly even custom data types.

I think once I get this to pass CI I will merge it since I've iterated a few times already and it's starting to get a little bigger than I should have let it, really... We're getting closer to a fully safe `triangle` example though!

----
TODOs remaining:
- [x] ~vector math, transformations etc. Might~ will save for another PR
- [x] Docstrings and general cleanup
- [x] Consider a more general API for binding uniforms to shaders, I don't love the idea of having a separate `update_blah` per matrix / vector type / dimension. Maybe a trait would be nice?