### PR TITLE
Use an Rc to keep render queue alive

### DIFF
--- a/citro3d/examples/triangle.rs
+++ b/citro3d/examples/triangle.rs
@@ -65,17 +65,20 @@ fn main() {
     let (mut top_left, mut top_right) = top_screen.split_mut();
 
     let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
-    let mut top_left_target =
-        render::Target::new(width, height, top_left, None).expect("failed to create render target");
+    let mut top_left_target = instance
+        .render_target(width, height, top_left, None)
+        .expect("failed to create render target");
 
     let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
-    let mut top_right_target = render::Target::new(width, height, top_right, None)
+    let mut top_right_target = instance
+        .render_target(width, height, top_right, None)
         .expect("failed to create render target");
 
     let mut bottom_screen = gfx.bottom_screen.borrow_mut();
     let RawFrameBuffer { width, height, .. } = bottom_screen.raw_framebuffer();
 
-    let mut bottom_target = render::Target::new(width, height, bottom_screen, None)
+    let mut bottom_target = instance
+        .render_target(width, height, bottom_screen, None)
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -107,11 +107,14 @@ impl Instance {
         render::Target::new(width, height, screen, depth_format, Rc::clone(&self.queue))
     }
 
-    /// Select the given render target for drawing the frame.
+    /// Select the given render target for drawing the frame. This must be called
+    /// as pare of a render call (i.e. within the call to
+    /// [`render_frame_with`](Self::render_frame_with)).
     ///
     /// # Errors
     ///
-    /// Fails if the given target cannot be used for drawing.
+    /// Fails if the given target cannot be used for drawing, or called outside
+    /// the context of a frame render.
     #[doc(alias = "C3D_FrameDrawOn")]
     pub fn select_render_target(&mut self, target: &render::Target<'_>) -> Result<()> {
         let _ = self;
@@ -286,7 +289,9 @@ mod tests {
         let mut instance = Instance::new().unwrap();
         let target = instance.render_target(10, 10, screen, None).unwrap();
 
-        instance.select_render_target(&target).unwrap();
+        instance.render_frame_with(|instance| {
+            instance.select_render_target(&target).unwrap();
+        });
 
         // Check that we don't get a double-free or use-after-free by dropping
         // the global instance before dropping the target.


### PR DESCRIPTION
Fixes #35 

Basically, give render targets an `Rc` to the global render queue to make sure it isn't freed/unlinked until after the render targets themselves are freed. This may not end up being the best way to deal with this but I think it should at least solve the immediate problem.

cc @Jhynjhiruu 

