### PR TITLE
Rewrite the maths & uniform API

### DIFF
--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.125"
 default = ["glam"]
 ## Enable this feature to use the `approx` crate for comparing vectors and matrices.
 approx = ["dep:approx"]
-# Enable for glam support in uniforms
+## Enable for glam support in uniforms
 glam = ["dep:glam"]
 
 [dev-dependencies]

--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+glam = { version = "0.25.0", optional = true }
 approx = { version = "0.5.1", optional = true }
 bitflags = "1.3.2"
 bytemuck = { version = "1.10.0", features = ["extern_crate_std"] }
@@ -17,9 +18,11 @@ document-features = "0.2.7"
 libc = "0.2.125"
 
 [features]
-default = []
+default = ["glam"]
 ## Enable this feature to use the `approx` crate for comparing vectors and matrices.
 approx = ["dep:approx"]
+# Enable for glam support in uniforms
+glam = ["dep:glam"]
 
 [dev-dependencies]
 test-runner = { git = "https://github.com/rust3ds/test-runner.git" }

--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-glam = { version = "0.25.0", optional = true }
+glam = { version = "0.24.2", optional = true }
 approx = { version = "0.5.1", optional = true }
 bitflags = "1.3.2"
 bytemuck = { version = "1.10.0", features = ["extern_crate_std"] }

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -192,8 +192,8 @@ impl Instance {
     /// let mtx = Matrix::identity();
     /// instance.bind_vertex_uniform(idx, &mtx);
     /// ```
-    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Uniform) {
-        uniform.bind(self, shader::Type::Vertex, index);
+    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
+        uniform.into().bind(self, shader::Type::Vertex, index);
     }
 
     /// Bind a uniform to the given `index` in the geometry shader for the next draw call.
@@ -210,8 +210,8 @@ impl Instance {
     /// let mtx = Matrix::identity();
     /// instance.bind_geometry_uniform(idx, &mtx);
     /// ```
-    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Uniform) {
-        uniform.bind(self, shader::Type::Geometry, index);
+    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
+        uniform.into().bind(self, shader::Type::Geometry, index);
     }
 
     /// Retrieve the [`TexEnv`] for the given stage, initializing it first if necessary.

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -16,9 +16,49 @@ pub use projection::{
 };
 
 /// A 4-vector of `u8`s.
+///
+/// # Layout
+/// Uses the PICA layout of WZYX
 #[doc(alias = "C3D_IVec")]
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct IVec(citro3d_sys::C3D_IVec);
+
+impl IVec {
+    pub fn new(x: u8, y: u8, z: u8, w: u8) -> Self {
+        Self(unsafe { citro3d_sys::IVec_Pack(x, y, z, w) })
+    }
+    pub fn as_raw(&self) -> &citro3d_sys::C3D_IVec {
+        &self.0
+    }
+    pub fn x(self) -> u8 {
+        self.0 as u8
+    }
+    pub fn y(self) -> u8 {
+        (self.0 >> 8) as u8
+    }
+    pub fn z(self) -> u8 {
+        (self.0 >> 16) as u8
+    }
+    pub fn w(self) -> u8 {
+        (self.0 >> 24) as u8
+    }
+}
 
 /// A quaternion, internally represented the same way as [`FVec`].
 #[doc(alias = "C3D_FQuat")]
 pub struct FQuat(citro3d_sys::C3D_FQuat);
+
+#[cfg(test)]
+mod tests {
+    use super::IVec;
+
+    #[test]
+    fn ivec_getters_work() {
+        let iv = IVec::new(1, 2, 3, 4);
+        assert_eq!(iv.x(), 1);
+        assert_eq!(iv.y(), 2);
+        assert_eq!(iv.z(), 3);
+        assert_eq!(iv.w(), 4);
+    }
+}

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -9,7 +9,7 @@ mod ops;
 mod projection;
 
 pub use fvec::{FVec, FVec3, FVec4};
-pub use matrix::{Matrix, Matrix3, Matrix4};
+pub use matrix::Matrix4;
 pub use projection::{
     AspectRatio, ClipPlanes, CoordinateOrientation, Orthographic, Perspective, Projection,
     ScreenOrientation, StereoDisplacement,

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -21,7 +21,7 @@ pub use projection::{
 /// Uses the PICA layout of WZYX
 #[doc(alias = "C3D_IVec")]
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct IVec(citro3d_sys::C3D_IVec);
 
 impl IVec {

--- a/citro3d/src/math/fvec.rs
+++ b/citro3d/src/math/fvec.rs
@@ -3,8 +3,15 @@
 use std::fmt;
 
 /// A vector of `f32`s.
+///
+/// # Layout
+/// Note that this matches the PICA layout so is actually WZYX, this means using it
+/// in vertex data as an attribute it will be reversed
+///
+/// It is guaranteed to have the same layout as [`citro3d_sys::C3D_FVec`] in memory
 #[derive(Clone, Copy)]
 #[doc(alias = "C3D_FVec")]
+#[repr(transparent)]
 pub struct FVec<const N: usize>(pub(crate) citro3d_sys::C3D_FVec);
 
 /// A 3-vector of `f32`s.

--- a/citro3d/src/math/fvec.rs
+++ b/citro3d/src/math/fvec.rs
@@ -250,6 +250,32 @@ impl FVec3 {
     }
 }
 
+#[cfg(feature = "glam")]
+impl From<glam::Vec4> for FVec4 {
+    fn from(value: glam::Vec4) -> Self {
+        Self::new(value.x, value.y, value.z, value.w)
+    }
+}
+#[cfg(feature = "glam")]
+impl From<glam::Vec3> for FVec3 {
+    fn from(value: glam::Vec3) -> Self {
+        Self::new(value.x, value.y, value.z)
+    }
+}
+#[cfg(feature = "glam")]
+impl From<FVec4> for glam::Vec4 {
+    fn from(value: FVec4) -> Self {
+        glam::Vec4::new(value.x(), value.y(), value.z(), value.w())
+    }
+}
+
+#[cfg(feature = "glam")]
+impl From<FVec3> for glam::Vec3 {
+    fn from(value: FVec3) -> Self {
+        glam::Vec3::new(value.x(), value.y(), value.z())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;

--- a/citro3d/src/math/fvec.rs
+++ b/citro3d/src/math/fvec.rs
@@ -55,6 +55,11 @@ impl FVec4 {
         unsafe { self.0.__bindgen_anon_1.w }
     }
 
+    /// Wrap a raw [`citro3d_sys::C3D_FVec`]
+    pub fn from_raw(raw: citro3d_sys::C3D_FVec) -> Self {
+        Self(raw)
+    }
+
     /// Create a new [`FVec4`] from its components.
     ///
     /// # Example

--- a/citro3d/src/math/matrix.rs
+++ b/citro3d/src/math/matrix.rs
@@ -183,12 +183,6 @@ impl core::fmt::Debug for Matrix4 {
         f.debug_tuple("Matrix4").field(&self.rows_wzyx()).finish()
     }
 }
-impl PartialEq<Matrix4> for Matrix4 {
-    fn eq(&self, other: &Matrix4) -> bool {
-        self.rows_wzyx() == other.rows_wzyx()
-    }
-}
-impl Eq for Matrix4 {}
 
 #[cfg(feature = "glam")]
 impl From<glam::Mat4> for Matrix4 {

--- a/citro3d/src/math/matrix.rs
+++ b/citro3d/src/math/matrix.rs
@@ -198,3 +198,17 @@ impl PartialEq<Matrix4> for Matrix4 {
     }
 }
 impl Eq for Matrix4 {}
+
+#[cfg(feature = "glam")]
+impl From<glam::Mat4> for Matrix4 {
+    fn from(mat: glam::Mat4) -> Self {
+        Matrix4::from_rows(core::array::from_fn(|i| mat.row(i).into()))
+    }
+}
+
+#[cfg(feature = "glam")]
+impl From<Matrix4> for glam::Mat4 {
+    fn from(mat: Matrix4) -> Self {
+        glam::Mat4::from_cols_array_2d(&mat.rows_xyzw()).transpose()
+    }
+}

--- a/citro3d/src/math/matrix.rs
+++ b/citro3d/src/math/matrix.rs
@@ -16,6 +16,20 @@ use super::{CoordinateOrientation, FVec3, FVec4};
 pub struct Matrix4(citro3d_sys::C3D_Mtx);
 
 impl Matrix4 {
+    /// Construct a Matrix4 from the cells
+    ///
+    /// # Note
+    /// This expects rows to be in WZYX order
+    pub fn from_cells_wzyx(cells: [f32; 16]) -> Self {
+        Self(citro3d_sys::C3D_Mtx { m: cells })
+    }
+    /// Construct a Matrix4 from its rows
+    pub fn from_rows(rows: [FVec4; 4]) -> Self {
+        Self(citro3d_sys::C3D_Mtx {
+            // Safety: FVec is repr(transparent)
+            r: unsafe { core::mem::transmute::<_, [citro3d_sys::C3D_FVec; 4]>(rows) },
+        })
+    }
     /// Create a new matrix from a raw citro3d_sys one
     pub fn from_raw(value: citro3d_sys::C3D_Mtx) -> Self {
         Self(value)
@@ -39,7 +53,7 @@ impl Matrix4 {
         unsafe { core::mem::transmute::<[citro3d_sys::C3D_FVec; 4], [FVec4; 4]>(self.0.r) }
     }
 
-    /// Get the rows in normal XYZW form
+    /// Get the rows in XYZW form
     pub fn rows_xyzw(self) -> [[f32; 4]; 4] {
         let mut rows = self.rows_wzyx();
         for r in &mut rows {
@@ -47,7 +61,7 @@ impl Matrix4 {
                 r.0.c.reverse();
             }
         }
-        // Safety: FVec has same layout as citro3d_sys version which is a union with [f32; 4] as one variant
+        // Safety: FVec has same layout as citro3d_sys::C3D_FVec which is a union with [f32; 4] as one variant
         unsafe { std::mem::transmute::<_, [[f32; 4]; 4]>(rows) }
     }
     /// Construct the zero matrix.

--- a/citro3d/src/math/matrix.rs
+++ b/citro3d/src/math/matrix.rs
@@ -26,8 +26,7 @@ impl Matrix4 {
     /// Construct a Matrix4 from its rows
     pub fn from_rows(rows: [FVec4; 4]) -> Self {
         Self(citro3d_sys::C3D_Mtx {
-            // Safety: FVec is repr(transparent)
-            r: unsafe { core::mem::transmute::<_, [citro3d_sys::C3D_FVec; 4]>(rows) },
+            r: rows.map(|r| r.0),
         })
     }
     /// Create a new matrix from a raw citro3d_sys one
@@ -49,20 +48,12 @@ impl Matrix4 {
 
     /// Get the rows in raw (WZYX) form
     pub fn rows_wzyx(self) -> [FVec4; 4] {
-        // Safety: FVec4 is repr(C) to allow transmute from C3D_Vec
-        unsafe { core::mem::transmute::<[citro3d_sys::C3D_FVec; 4], [FVec4; 4]>(self.0.r) }
+        unsafe { self.0.r }.map(FVec4::from_raw)
     }
 
     /// Get the rows in XYZW form
     pub fn rows_xyzw(self) -> [[f32; 4]; 4] {
-        let mut rows = self.rows_wzyx();
-        for r in &mut rows {
-            unsafe {
-                r.0.c.reverse();
-            }
-        }
-        // Safety: FVec has same layout as citro3d_sys::C3D_FVec which is a union with [f32; 4] as one variant
-        unsafe { std::mem::transmute::<_, [[f32; 4]; 4]>(rows) }
+        self.rows_wzyx().map(|r| [r.x(), r.y(), r.z(), r.w()])
     }
     /// Construct the zero matrix.
     #[doc(alias = "Mtx_Zeros")]

--- a/citro3d/src/math/ops.rs
+++ b/citro3d/src/math/ops.rs
@@ -190,6 +190,12 @@ impl Mul<FVec3> for &Matrix4 {
     }
 }
 
+impl PartialEq<Matrix4> for Matrix4 {
+    fn eq(&self, other: &Matrix4) -> bool {
+        self.rows_wzyx() == other.rows_wzyx()
+    }
+}
+
 // endregion
 
 #[cfg(feature = "approx")]

--- a/citro3d/src/math/ops.rs
+++ b/citro3d/src/math/ops.rs
@@ -1,6 +1,5 @@
-use std::borrow::Borrow;
 use std::mem::MaybeUninit;
-use std::ops::{Add, Deref, Div, Mul, Neg, Sub};
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 #[cfg(feature = "approx")]
 use approx::AbsDiffEq;

--- a/citro3d/src/math/ops.rs
+++ b/citro3d/src/math/ops.rs
@@ -248,24 +248,12 @@ mod tests {
     }
 
     #[test]
-    fn matrix3() {
-        let l = Matrix3::diagonal(1.0, 2.0, 3.0);
-        let r = Matrix3::identity();
-        let (l, r) = (&l, &r);
-
-        assert_abs_diff_eq!(&(l * r), l);
-        assert_abs_diff_eq!(&(l + r), &Matrix3::diagonal(2.0, 3.0, 4.0));
-        assert_abs_diff_eq!(&(l - r), &Matrix3::diagonal(0.0, 1.0, 2.0));
-    }
-
-    #[test]
     fn matrix4() {
         let l = Matrix4::diagonal(1.0, 2.0, 3.0, 4.0);
         let r = Matrix4::identity();
-        let (l, r) = (&l, &r);
 
-        assert_abs_diff_eq!(&(l * r), l);
-        assert_abs_diff_eq!(&(l + r), &Matrix4::diagonal(2.0, 3.0, 4.0, 5.0));
-        assert_abs_diff_eq!(&(l - r), &Matrix4::diagonal(0.0, 1.0, 2.0, 3.0));
+        assert_abs_diff_eq!(l * r, l);
+        assert_abs_diff_eq!(l + r, Matrix4::diagonal(2.0, 3.0, 4.0, 5.0));
+        assert_abs_diff_eq!(l - r, Matrix4::diagonal(0.0, 1.0, 2.0, 3.0));
     }
 }

--- a/citro3d/src/math/projection.rs
+++ b/citro3d/src/math/projection.rs
@@ -209,7 +209,7 @@ impl From<Projection<Perspective>> for Matrix4 {
             }
         }
 
-        unsafe { Self::new(result.assume_init()) }
+        unsafe { Self::from_raw(result.assume_init()) }
     }
 }
 
@@ -285,7 +285,7 @@ impl From<Projection<Orthographic>> for Matrix4 {
                 clip_planes_z.far,
                 projection.coordinates.is_left_handed(),
             );
-            Self::new(out.assume_init())
+            Self::from_raw(out.assume_init())
         }
     }
 }

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -96,7 +96,7 @@ impl Program {
         if idx < 0 {
             Err(crate::Error::NotFound)
         } else {
-            Ok(idx.into())
+            Ok((idx as u8).into())
         }
     }
 
@@ -116,6 +116,7 @@ impl Drop for Program {
 
 /// The type of a shader.
 #[repr(u32)]
+#[derive(Clone, Copy)]
 pub enum Type {
     /// A vertex shader.
     Vertex = ctru_sys::GPU_VERTEX_SHADER,

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -24,6 +24,7 @@ impl From<Index> for i32 {
 
 /// A uniform which may be bound as input to a shader program
 #[non_exhaustive]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Uniform {
     /// Single float uniform (`.fvec name`)
     Float(FVec4),

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -43,23 +43,23 @@ impl Uniform {
         // these indexes are from the uniform table in the shader see: https://www.3dbrew.org/wiki/SHBIN#Uniform_Table_Entry
         // the input registers then are excluded by libctru, see: https://github.com/devkitPro/libctru/blob/0da8705527f03b4b08ff7fee4dd1b7f28df37905/libctru/source/gpu/shbin.c#L93
         match self {
-            Uniform::Float(_) | Uniform::Float2(_) | Uniform::Float3(_) | Uniform::Float4(_) => {
+            Self::Float(_) | Self::Float2(_) | Self::Float3(_) | Self::Float4(_) => {
                 Index(0)..Index(0x60)
             }
-            Uniform::Int(_) => Index(0x60)..Index(0x64),
+            Self::Int(_) => Index(0x60)..Index(0x64),
             // this gap is intentional
-            Uniform::Bool(_) => Index(0x68)..Index(0x79),
+            Self::Bool(_) => Index(0x68)..Index(0x79),
         }
     }
     /// Get length of uniform, i.e. how many registers it will write to
     #[allow(clippy::len_without_is_empty)] // is_empty doesn't make sense here
     pub fn len(&self) -> usize {
         match self {
-            Uniform::Float(_) => 1,
-            Uniform::Float2(_) => 2,
-            Uniform::Float3(_) => 3,
-            Uniform::Float4(_) => 4,
-            Uniform::Bool(_) | Uniform::Int(_) => 1,
+            Self::Float(_) => 1,
+            Self::Float2(_) => 2,
+            Self::Float3(_) => 3,
+            Self::Float4(_) => 4,
+            Self::Bool(_) | Uniform::Int(_) => 1,
         }
     }
 
@@ -91,10 +91,10 @@ impl Uniform {
             }
         };
         match self {
-            Uniform::Bool(b) => unsafe {
+            Self::Bool(b) => unsafe {
                 citro3d_sys::C3D_BoolUnifSet(ty.into(), index.into(), b);
             },
-            Uniform::Int(i) => unsafe {
+            Self::Int(i) => unsafe {
                 citro3d_sys::C3D_IVUnifSet(
                     ty.into(),
                     index.into(),
@@ -104,12 +104,12 @@ impl Uniform {
                     i.w() as i32,
                 );
             },
-            Uniform::Float(f) => set_fvs(&[f]),
-            Uniform::Float2(fs) => {
+            Self::Float(f) => set_fvs(&[f]),
+            Self::Float2(fs) => {
                 set_fvs(&fs);
             }
-            Uniform::Float3(fs) => set_fvs(&fs),
-            Uniform::Float4(m) => {
+            Self::Float3(fs) => set_fvs(&fs),
+            Self::Float4(m) => {
                 set_fvs(&m.rows_wzyx());
             }
         }

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -23,6 +23,7 @@ impl From<Index> for i32 {
 }
 
 /// A uniform which may be bound as input to a shader program
+#[non_exhaustive]
 pub enum Uniform {
     /// Single float uniform (`.fvec name`)
     Float(FVec4),

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -27,16 +27,22 @@ impl From<Index> for i32 {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Uniform {
     /// Single float uniform (`.fvec name`)
+    #[doc(alias = "C3D_FVUnifSet")]
     Float(FVec4),
     /// Two element float uniform (`.fvec name[2]`)
+    #[doc(alias = "C3D_FVUnifMtx2x4")]
     Float2([FVec4; 2]),
     /// Three element float uniform (`.fvec name [3]`)
+    #[doc(alias = "C3D_FVUnifMtx3x4")]
     Float3([FVec4; 3]),
     /// Matrix/4 element float uniform (`.fvec name[4]`)
+    #[doc(alias = "C3D_FVUnifMtx4x4")]
     Float4(Matrix4),
     /// Bool uniform (`.bool name`)
+    #[doc(alias = "C3D_BoolUnifSet")]
     Bool(bool),
     /// Integer uniform (`.ivec name`)
+    #[doc(alias = "C3D_IVUnifSet")]
     Int(IVec),
 }
 impl Uniform {

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -70,12 +70,11 @@ impl Uniform {
     pub(crate) fn bind(self, _instance: &mut Instance, ty: shader::Type, index: Index) {
         assert!(
             self.index_range().contains(&index),
-            "tried to bind uniform to an invalid index (index: {}, valid range: {}..{})",
-            index.0,
-            self.index_range().start.0,
-            self.index_range().end.0
+            "tried to bind uniform to an invalid index (index: {:?}, valid range: {:?})",
+            index,
+            self.index_range(),
         );
-        assert!(self.index_range().end.0 as usize >= self.len() + index.0 as usize, "tried to bind a uniform that would overflow the uniform buffer. index was {}, size was {} max is {}", index.0, self.len(), self.index_range().end.0);
+        assert!(self.index_range().end.0 as usize >= self.len() + index.0 as usize, "tried to bind a uniform that would overflow the uniform buffer. index was {:?}, size was {} max is {:?}", index, self.len(), self.index_range().end);
         let set_fvs = |fs: &[FVec4]| {
             for (off, f) in fs.iter().enumerate() {
                 unsafe {

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -22,17 +22,23 @@ impl From<Index> for i32 {
     }
 }
 
-/// A shader uniform. This trait is implemented for types that can be bound to
-/// shaders to be used as a uniform input to the shader.
+/// A uniform which may be bound as input to a shader program
 pub enum Uniform {
+    /// Single float uniform (`.fvec name`)
     Float(FVec4),
+    /// Two element float uniform (`.fvec name[2]`)
     Float2([FVec4; 2]),
+    /// Three element float uniform (`.fvec name [3]`)
     Float3([FVec4; 3]),
+    /// Matrix/4 element float uniform (`.fvec name[4]`)
     Float4(Matrix4),
+    /// Bool uniform (`.bool name`)
     Bool(bool),
+    /// Integer uniform (`.ivec name`)
     Int(IVec),
 }
 impl Uniform {
+    /// Get range of valid indexes for this uniform to bind to
     pub fn index_range(&self) -> Range<Index> {
         // these indexes are from the uniform table in the shader see: https://www.3dbrew.org/wiki/SHBIN#Uniform_Table_Entry
         // the input registers then are excluded by libctru, see: https://github.com/devkitPro/libctru/blob/0da8705527f03b4b08ff7fee4dd1b7f28df37905/libctru/source/gpu/shbin.c#L93
@@ -45,6 +51,8 @@ impl Uniform {
             Uniform::Bool(_) => Index(0x68)..Index(0x79),
         }
     }
+    /// Get length of uniform, i.e. how many registers it will write to
+    #[allow(clippy::len_without_is_empty)] // is_empty doesn't make sense here
     pub fn len(&self) -> usize {
         match self {
             Uniform::Float(_) => 1,

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -144,3 +144,17 @@ impl From<&Matrix4> for Uniform {
         (*value).into()
     }
 }
+
+#[cfg(feature = "glam")]
+impl From<glam::Vec4> for Uniform {
+    fn from(value: glam::Vec4) -> Self {
+        Self::Float(value.into())
+    }
+}
+
+#[cfg(feature = "glam")]
+impl From<glam::Mat4> for Uniform {
+    fn from(value: glam::Mat4) -> Self {
+        Self::Float4(value.into())
+    }
+}

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -1,15 +1,17 @@
 //! Common definitions for binding uniforms to shaders. This is primarily
 //! done by implementing the [`Uniform`] trait for a given type.
 
-use crate::math::Matrix;
+use std::ops::Range;
+
+use crate::math::{FVec4, IVec, Matrix4};
 use crate::{shader, Instance};
 
 /// The index of a uniform within a [`shader::Program`].
-#[derive(Copy, Clone, Debug)]
-pub struct Index(i8);
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Index(u8);
 
-impl From<i8> for Index {
-    fn from(value: i8) -> Self {
+impl From<u8> for Index {
+    fn from(value: u8) -> Self {
         Self(value)
     }
 }
@@ -20,38 +22,125 @@ impl From<Index> for i32 {
     }
 }
 
-mod private {
-    use crate::math::Matrix;
-
-    pub trait Sealed {}
-
-    impl<const M: usize, const N: usize> Sealed for &Matrix<M, N> {}
-}
-
 /// A shader uniform. This trait is implemented for types that can be bound to
 /// shaders to be used as a uniform input to the shader.
-pub trait Uniform: private::Sealed {
-    /// Bind the uniform to the given shader index for the given shader type.
-    /// An [`Instance`] is required to prevent concurrent binding of different
-    /// uniforms to the same index.
-    fn bind(self, instance: &mut Instance, shader_type: shader::Type, index: Index);
+pub enum Uniform {
+    Float(FVec4),
+    Float2([FVec4; 2]),
+    Float3([FVec4; 3]),
+    Float4(Matrix4),
+    Bool(bool),
+    Int(IVec),
+}
+impl Uniform {
+    pub fn index_range(&self) -> Range<Index> {
+        // these indexes are from the uniform table in the shader see: https://www.3dbrew.org/wiki/SHBIN#Uniform_Table_Entry
+        // the input registers then are excluded by libctru, see: https://github.com/devkitPro/libctru/blob/0da8705527f03b4b08ff7fee4dd1b7f28df37905/libctru/source/gpu/shbin.c#L93
+        match self {
+            Uniform::Float(_) | Uniform::Float2(_) | Uniform::Float3(_) | Uniform::Float4(_) => {
+                Index(0)..Index(0x60)
+            }
+            Uniform::Int(_) => Index(0x60)..Index(0x64),
+            // this gap is intentional
+            Uniform::Bool(_) => Index(0x68)..Index(0x79),
+        }
+    }
+    pub fn len(&self) -> usize {
+        match self {
+            Uniform::Float(_) => 1,
+            Uniform::Float2(_) => 2,
+            Uniform::Float3(_) => 3,
+            Uniform::Float4(_) => 4,
+            Uniform::Bool(_) | Uniform::Int(_) => 1,
+        }
+    }
+
+    /// Bind a uniform
+    ///
+    /// Note: `_instance` is here to ensure unique access to the global uniform buffers
+    /// otherwise we could race and/or violate aliasing
+    pub(crate) fn bind(self, _instance: &mut Instance, ty: shader::Type, index: Index) {
+        assert!(
+            self.index_range().contains(&index),
+            "tried to bind uniform to an invalid index (index: {}, valid range: {}..{})",
+            index.0,
+            self.index_range().start.0,
+            self.index_range().end.0
+        );
+        assert!(self.index_range().end.0 as usize >= self.len() + index.0 as usize, "tried to bind a uniform that would overflow the uniform buffer. index was {}, size was {} max is {}", index.0, self.len(), self.index_range().end.0);
+        let set_fvs = |fs: &[FVec4]| {
+            for (off, f) in fs.iter().enumerate() {
+                unsafe {
+                    citro3d_sys::C3D_FVUnifSet(
+                        ty.into(),
+                        (index.0 as usize + off) as i32,
+                        f.x(),
+                        f.y(),
+                        f.z(),
+                        f.w(),
+                    );
+                }
+            }
+        };
+        match self {
+            Uniform::Bool(b) => unsafe {
+                citro3d_sys::C3D_BoolUnifSet(ty.into(), index.into(), b);
+            },
+            Uniform::Int(i) => unsafe {
+                citro3d_sys::C3D_IVUnifSet(
+                    ty.into(),
+                    index.into(),
+                    i.x() as i32,
+                    i.y() as i32,
+                    i.z() as i32,
+                    i.w() as i32,
+                );
+            },
+            Uniform::Float(f) => set_fvs(&[f]),
+            Uniform::Float2(fs) => {
+                set_fvs(&fs);
+            }
+            Uniform::Float3(fs) => set_fvs(&fs),
+            Uniform::Float4(m) => {
+                set_fvs(&m.rows_wzyx());
+            }
+        }
+    }
 }
 
-impl<const M: usize> Uniform for &Matrix<M, 4> {
-    #[doc(alias = "C34_FVUnifMtxNx4")]
-    #[doc(alias = "C34_FVUnifMtx4x4")]
-    #[doc(alias = "C34_FVUnifMtx3x4")]
-    #[doc(alias = "C34_FVUnifMtx2x4")]
-    fn bind(self, _instance: &mut Instance, type_: shader::Type, index: Index) {
-        unsafe {
-            citro3d_sys::C3D_FVUnifMtxNx4(
-                type_.into(),
-                index.into(),
-                self.as_raw(),
-                // UNWRAP: it should be impossible for end users to construct
-                // a matrix with M > i32::MAX
-                M.try_into().unwrap(),
-            );
-        }
+impl From<Matrix4> for Uniform {
+    fn from(value: Matrix4) -> Self {
+        Self::Float4(value)
+    }
+}
+impl From<[FVec4; 3]> for Uniform {
+    fn from(value: [FVec4; 3]) -> Self {
+        Self::Float3(value)
+    }
+}
+
+impl From<[FVec4; 2]> for Uniform {
+    fn from(value: [FVec4; 2]) -> Self {
+        Self::Float2(value)
+    }
+}
+impl From<FVec4> for Uniform {
+    fn from(value: FVec4) -> Self {
+        Self::Float(value)
+    }
+}
+impl From<IVec> for Uniform {
+    fn from(value: IVec) -> Self {
+        Self::Int(value)
+    }
+}
+impl From<bool> for Uniform {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+impl From<&Matrix4> for Uniform {
+    fn from(value: &Matrix4) -> Self {
+        (*value).into()
     }
 }


### PR DESCRIPTION
So theres quite a lot here and I'm aware it might not fly as its a substantial change, though it is mostly non-breaking it does remove some functionality. 

Matrix and Matrix3 are gone. My thought process is that there are not many use-cases for the 3x3 stuff since basically all you can use it for is CPU math which the rust ecosystem already has stuff for.

`Matrix4`'s API has been made more explicit about the row order and has been made `Copy`, also it no longer gives out pointers to the inner as that's just asking for trouble. If unsafe code wants to cast the reference to a pointer that's its business. 

Uniform is now an enum rather than a sealed trait. This gives us some nice things: 
- we express all the possible options up front rather than hidden in many impl's
- consumers can make their own types work as uniforms by implementing `From<MyType> for Uniform` 

also I added the missing bindings and fixed the soundness issue where an overflow could occure


[glam](https://docs.rs/glam/latest/glam/index.html) interop with `From` impl's for `FVec`, `Matrix4`, and `Uniform` (which lets you bind glam mat4's directly as uniforms), this should help with that CPU math