### PR TITLE
Implement short enums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         toolchain:
           # Run against a "known good" nightly. Rustc version is 1 day behind the toolchain date
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           # Check for breakage on latest nightly
           - nightly
 
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           - nightly
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: rust3ds/test-runner/setup@v1
         with:
-          toolchain: nightly-2023-06-01
+          toolchain: nightly-2024-02-18
 
       - name: Build workspace docs
         run: cargo 3ds --verbose doc --verbose --no-deps --workspace

--- a/citro3d-sys/build.rs
+++ b/citro3d-sys/build.rs
@@ -93,6 +93,7 @@ fn main() {
             "-DARM11 ",
             "-D_3DS ",
             "-D__3DS__ ",
+            "-fshort-enums",
         ])
         .parse_callbacks(Box::new(CustomCallbacks))
         .generate()

--- a/citro3d-sys/src/gx.rs
+++ b/citro3d-sys/src/gx.rs
@@ -20,15 +20,15 @@ pub fn GX_TRANSFER_RAW_COPY(raw_copy: bool) -> u32 {
 
 #[inline]
 pub fn GX_TRANSFER_IN_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
-    format << 8
+    (format as u32) << 8
 }
 
 #[inline]
 pub fn GX_TRANSFER_OUT_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
-    format << 12
+    (format as u32) << 12
 }
 
 #[inline]
 pub fn GX_TRANSFER_SCALING(scale: GX_TRANSFER_SCALE) -> u32 {
-    scale << 24
+    (scale as u32) << 24
 }

--- a/citro3d/src/attrib.rs
+++ b/citro3d/src/attrib.rs
@@ -38,11 +38,12 @@ impl Register {
 /// An attribute index. This is the attribute's actual index in the input buffer,
 /// and may correspond to any [`Register`] (or multiple) as input in the shader
 /// program.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct Index(u8);
 
 /// The data format of an attribute.
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy)]
 #[doc(alias = "GPU_FORMATS")]
 pub enum Format {
@@ -54,6 +55,12 @@ pub enum Format {
     Float = ctru_sys::GPU_FLOAT,
     /// A short integer, i.e. [`i16`].
     Short = ctru_sys::GPU_SHORT,
+}
+
+impl From<Format> for u8 {
+    fn from(value: Format) -> Self {
+        value as u8
+    }
 }
 
 // SAFETY: the RWLock ensures unique access when mutating the global struct, and
@@ -117,7 +124,7 @@ impl Info {
         // SAFETY: the &mut self.0 reference is only used to access fields in
         // the attribute info, not stored somewhere for later use
         let ret = unsafe {
-            citro3d_sys::AttrInfo_AddLoader(&mut self.0, register.0, format as u32, count.into())
+            citro3d_sys::AttrInfo_AddLoader(&mut self.0, register.0, format.into(), count.into())
         };
 
         let Ok(idx) = ret.try_into() else {

--- a/citro3d/src/buffer.rs
+++ b/citro3d/src/buffer.rs
@@ -49,7 +49,7 @@ impl Slice<'_> {
 }
 
 /// The geometric primitive to draw (i.e. what shapes the buffer data describes).
-#[repr(u32)]
+#[repr(u16)]
 #[derive(Debug, Clone, Copy)]
 #[doc(alias = "GPU_Primitive_t")]
 pub enum Primitive {

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -216,11 +216,11 @@ impl Instance {
     /// ```
     /// # let _runner = test_runner::GdbRunner::default();
     /// # use citro3d::uniform;
-    /// # use citro3d::math::Matrix;
+    /// # use citro3d::math::Matrix4;
     /// #
     /// # let mut instance = citro3d::Instance::new().unwrap();
     /// let idx = uniform::Index::from(0);
-    /// let mtx = Matrix::identity();
+    /// let mtx = Matrix4::identity();
     /// instance.bind_vertex_uniform(idx, &mtx);
     /// ```
     pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
@@ -234,11 +234,11 @@ impl Instance {
     /// ```
     /// # let _runner = test_runner::GdbRunner::default();
     /// # use citro3d::uniform;
-    /// # use citro3d::math::Matrix;
+    /// # use citro3d::math::Matrix4;
     /// #
     /// # let mut instance = citro3d::Instance::new().unwrap();
     /// let idx = uniform::Index::from(0);
-    /// let mtx = Matrix::identity();
+    /// let mtx = Matrix4::identity();
     /// instance.bind_geometry_uniform(idx, &mtx);
     /// ```
     pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -141,7 +141,7 @@ impl Instance {
         unsafe {
             citro3d_sys::C3D_FrameBegin(
                 // TODO: begin + end flags should be configurable
-                citro3d_sys::C3D_FRAME_SYNCDRAW.try_into().unwrap(),
+                citro3d_sys::C3D_FRAME_SYNCDRAW,
             );
         }
 

--- a/citro3d/src/math.rs
+++ b/citro3d/src/math.rs
@@ -46,6 +46,7 @@ impl IVec {
 }
 
 /// A quaternion, internally represented the same way as [`FVec`].
+#[allow(dead_code)]
 #[doc(alias = "C3D_FQuat")]
 pub struct FQuat(citro3d_sys::C3D_FQuat);
 

--- a/citro3d/src/math/projection.rs
+++ b/citro3d/src/math/projection.rs
@@ -7,7 +7,7 @@ use super::Matrix4;
 /// See specific `Kind` implementations for constructors, e.g.
 /// [`Projection::perspective`] and [`Projection::orthographic`].
 ///
-/// To use the resulting projection, convert it to a [`Matrix`](super::Matrix) with [`From`]/[`Into`].
+/// To use the resulting projection, convert it to a [`Matrix4`] with [`From`]/[`Into`].
 #[derive(Clone, Debug)]
 pub struct Projection<Kind> {
     coordinates: CoordinateOrientation,
@@ -151,7 +151,7 @@ impl Projection<Perspective> {
         right_eye: StereoDisplacement,
     ) -> (Matrix4, Matrix4) {
         // TODO: we might be able to avoid this clone if there was a conversion
-        // from &Self to Matrix instead of Self... but it's probably fine for now
+        // from &Self to Matrix4 instead of Self... but it's probably fine for now
         let left = self.clone().stereo(left_eye);
         let right = self.stereo(right_eye);
         // Also, we could consider just returning (Self, Self) here? idk

--- a/citro3d/src/render.rs
+++ b/citro3d/src/render.rs
@@ -100,7 +100,7 @@ impl<'screen> Target<'screen> {
 bitflags::bitflags! {
     /// Indicate whether color, depth buffer, or both values should be cleared.
     #[doc(alias = "C3D_ClearBits")]
-    pub struct ClearFlags: u32 {
+    pub struct ClearFlags: u8 {
         /// Clear the color of the render target.
         const COLOR = citro3d_sys::C3D_CLEAR_COLOR;
         /// Clear the depth buffer value of the render target.
@@ -111,7 +111,7 @@ bitflags::bitflags! {
 }
 
 /// The color format to use when rendering on the GPU.
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Clone, Copy, Debug)]
 #[doc(alias = "GPU_COLORBUF")]
 pub enum ColorFormat {
@@ -141,7 +141,7 @@ impl From<FramebufferFormat> for ColorFormat {
 }
 
 /// The depth buffer format to use when rendering.
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Clone, Copy, Debug)]
 #[doc(alias = "GPU_DEPTHBUF")]
 #[doc(alias = "C3D_DEPTHTYPE")]

--- a/citro3d/src/render/transfer.rs
+++ b/citro3d/src/render/transfer.rs
@@ -31,7 +31,7 @@ impl Flags {
 /// NOTE: this a distinct type from [`ColorFormat`] because they are not implicitly
 /// convertible to one another. Use [`From::from`] to get the [`Format`] corresponding
 /// to a given [`ColorFormat`].
-#[repr(u32)]
+#[repr(u8)]
 #[doc(alias = "GX_TRANSFER_FORMAT")]
 pub enum Format {
     /// 8-bit Red + 8-bit Green + 8-bit Blue + 8-bit Alpha.

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -115,7 +115,7 @@ impl Drop for Program {
 }
 
 /// The type of a shader.
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Clone, Copy)]
 pub enum Type {
     /// A vertex shader.
@@ -124,9 +124,9 @@ pub enum Type {
     Geometry = ctru_sys::GPU_GEOMETRY_SHADER,
 }
 
-impl From<Type> for u32 {
+impl From<Type> for u8 {
     fn from(value: Type) -> Self {
-        value as u32
+        value as u8
     }
 }
 

--- a/citro3d/src/texenv.rs
+++ b/citro3d/src/texenv.rs
@@ -85,7 +85,7 @@ bitflags! {
 #[doc(alias = "GPU_TEVSRC")]
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy)]
-#[repr(u32)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum Source {
     PrimaryColor = ctru_sys::GPU_PRIMARY_COLOR,
@@ -104,7 +104,7 @@ pub enum Source {
 #[doc(alias = "GPU_COMBINEFUNC")]
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy)]
-#[repr(u32)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum CombineFunc {
     Replace = ctru_sys::GPU_REPLACE,


### PR DESCRIPTION
Closes #46 
Following the changes of https://github.com/rust3ds/ctru-rs/pull/180

Change the bindgen to force the use of short enums and fix the type definitions to accomodate the changes.