### PR TITLE
[Feature] Lighting

### DIFF
--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -16,6 +16,7 @@ ctru-rs = { git = "https://github.com/rust3ds/ctru-rs.git" }
 ctru-sys = { git = "https://github.com/rust3ds/ctru-rs.git" }
 document-features = "0.2.7"
 libc = "0.2.125"
+pin_array = { version = "0.1.0" }
 
 [features]
 default = ["glam"]

--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -16,7 +16,7 @@ ctru-rs = { git = "https://github.com/rust3ds/ctru-rs.git" }
 ctru-sys = { git = "https://github.com/rust3ds/ctru-rs.git" }
 document-features = "0.2.7"
 libc = "0.2.125"
-pin_array = { version = "0.1.0" }
+pin_array = { version = "0.1.1" }
 
 [features]
 default = ["glam"]

--- a/citro3d/examples/assets/frag-shader.pica
+++ b/citro3d/examples/assets/frag-shader.pica
@@ -1,0 +1,73 @@
+; modified version of https://github.com/devkitPro/3ds-examples/blob/ea519187782397c279609da80310e0f8c7e80f09/graphics/gpu/fragment_light/source/vshader.v.pica
+; Example PICA200 vertex shader
+
+; Uniforms
+.fvec projection[4], modelView[4]
+
+; Constants
+.constf myconst(0.0, 1.0, -1.0, 0.5)
+.alias  zeros myconst.xxxx ; Vector full of zeros
+.alias  ones  myconst.yyyy ; Vector full of ones
+.alias  half  myconst.wwww
+
+; Outputs
+.out outpos position
+.out outtc0 texcoord0
+.out outclr color
+.out outview view
+.out outnq normalquat
+
+; Inputs (defined as aliases for convenience)
+.alias inpos v0
+.alias innrm v1
+
+.proc main
+	; Force the w component of inpos to be 1.0
+	mov r0.xyz, inpos
+	mov r0.w,   ones
+
+	; r1 = modelView * inpos
+	dp4 r1.x, modelView[0], r0
+	dp4 r1.y, modelView[1], r0
+	dp4 r1.z, modelView[2], r0
+	dp4 r1.w, modelView[3], r0
+
+	; outview = -r1
+	mov outview, -r1
+
+	; outpos = projection * r1
+	dp4 outpos.x, projection[0], r1
+	dp4 outpos.y, projection[1], r1
+	dp4 outpos.z, projection[2], r1
+	dp4 outpos.w, projection[3], r1
+
+	; outtex = intex
+	;mov outtc0, intex
+
+	; Transform the normal vector with the modelView matrix
+	; TODO: use a separate normal matrix that is the transpose of the inverse of modelView
+	dp3 r14.x, modelView[0], innrm
+	dp3 r14.y, modelView[1], innrm
+	dp3 r14.z, modelView[2], innrm
+	dp3 r6.x, r14, r14
+	rsq r6.x, r6.x
+	mul r14.xyz, r14.xyz, r6.x
+
+	mov r0, myconst.yxxx
+	add r4, ones, r14.z
+	mul r4, half, r4
+	cmp zeros, ge, ge, r4.x
+	rsq r4, r4.x
+	mul r5, half, r14
+	jmpc cmp.x, degenerate
+
+	rcp r0.z, r4.x
+	mul r0.xy, r5, r4
+
+degenerate:
+	mov outnq, r0
+	mov outclr, ones
+
+	; We're finished
+	end
+.end

--- a/citro3d/examples/assets/frag-shader.pica
+++ b/citro3d/examples/assets/frag-shader.pica
@@ -12,14 +12,15 @@
 
 ; Outputs
 .out outpos position
-.out outtc0 texcoord0
+.out outtex texcoord0
 .out outclr color
 .out outview view
 .out outnq normalquat
 
 ; Inputs (defined as aliases for convenience)
-.alias inpos v0
-.alias innrm v1
+.in inpos
+.in innrm
+.in intex
 
 .proc main
 	; Force the w component of inpos to be 1.0
@@ -42,7 +43,7 @@
 	dp4 outpos.w, projection[3], r1
 
 	; outtex = intex
-	;mov outtc0, intex
+	mov outtex, intex
 
 	; Transform the normal vector with the modelView matrix
 	; TODO: use a separate normal matrix that is the transpose of the inverse of modelView

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -268,33 +268,36 @@ fn main() {
     let (mut top_left, mut top_right) = top_screen.split_mut();
 
     let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
-    let mut top_left_target = render::Target::new(
-        width,
-        height,
-        top_left,
-        Some(render::DepthFormat::Depth24Stencil8),
-    )
-    .expect("failed to create render target");
+    let mut top_left_target = instance
+        .render_target(
+            width,
+            height,
+            top_left,
+            Some(render::DepthFormat::Depth24Stencil8),
+        )
+        .expect("failed to create render target");
 
     let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
-    let mut top_right_target = render::Target::new(
-        width,
-        height,
-        top_right,
-        Some(render::DepthFormat::Depth24Stencil8),
-    )
-    .expect("failed to create render target");
+    let mut top_right_target = instance
+        .render_target(
+            width,
+            height,
+            top_right,
+            Some(render::DepthFormat::Depth24Stencil8),
+        )
+        .expect("failed to create render target");
 
     let mut bottom_screen = gfx.bottom_screen.borrow_mut();
     let RawFrameBuffer { width, height, .. } = bottom_screen.raw_framebuffer();
 
-    let mut bottom_target = render::Target::new(
-        width,
-        height,
-        bottom_screen,
-        Some(render::DepthFormat::Depth24Stencil8),
-    )
-    .expect("failed to create bottom screen render target");
+    let mut bottom_target = instance
+        .render_target(
+            width,
+            height,
+            bottom_screen,
+            Some(render::DepthFormat::Depth24Stencil8),
+        )
+        .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
     let vertex_shader = shader.get(0).unwrap();

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -1,7 +1,7 @@
 #![feature(allocator_api)]
 use citro3d::{
     attrib, buffer,
-    light::{FresnelSelector, LightEnv, LightLutId, LutData, LutInput},
+    light::{FresnelSelector, LightEnv, LightLut, LightLutId, LutInput},
     material::{Color, Material},
     math::{AspectRatio, ClipPlanes, FVec3, FVec4, Matrix4, Projection, StereoDisplacement},
     render::{self, ClearFlags},
@@ -309,7 +309,7 @@ fn main() {
     light_env.as_mut().connect_lut(
         LightLutId::D0,
         LutInput::LightNormal,
-        LutData::from_fn(|v| v.powf(10.0), false),
+        LightLut::from_fn(|v| v.powf(10.0), false),
     );
     light_env.as_mut().set_material(Material {
         ambient: Some(Color::new(0.2, 0.2, 0.2)),

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -298,18 +298,20 @@ fn main() {
 
     let mut buf_info = buffer::Info::new();
     let (attr_info, vbo_data) = prepare_vbos(&mut buf_info, &vbo_data);
-    let light_env = instance.light_env_mut();
-    light_env.connect_lut(LightLutId::D0, LutInput::LightNormal, LutData::phong(30.0));
-    light_env.set_material(Material {
+    let mut light_env = instance.light_env_mut();
+    light_env
+        .as_mut()
+        .connect_lut(LightLutId::D0, LutInput::LightNormal, LutData::phong(30.0));
+    light_env.as_mut().set_material(Material {
         ambient: Some(Color::new(0.2, 0.2, 0.2)),
         diffuse: Some(Color::new(1.0, 0.4, 1.0)),
         specular0: Some(Color::new(0.8, 0.8, 0.8)),
         ..Default::default()
     });
-    let light = light_env.create_light().unwrap();
-    let light = light_env.light_mut(light).unwrap();
-    light.set_color(1.0, 1.0, 1.0);
-    light.set_position(FVec3::new(0.0, 0.0, -0.5));
+    let light = light_env.as_mut().create_light().unwrap();
+    let mut light = light_env.as_mut().light_mut(light).unwrap();
+    light.as_mut().set_color(1.0, 1.0, 1.0);
+    light.as_mut().set_position(FVec3::new(0.0, 0.0, -0.5));
     let mut c = Matrix4::identity();
     let model_idx = program.get_uniform("modelView").unwrap();
     c.translate(0.0, 0.0, -2.0);

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -28,77 +28,216 @@ impl Vec3 {
         Self { x, y, z }
     }
 }
+#[derive(Copy, Clone)]
+#[repr(C)]
+struct Vec2 {
+    x: f32,
+    y: f32,
+}
+
+impl Vec2 {
+    const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct Vertex {
     pos: Vec3,
     normal: Vec3,
+    uv: Vec2,
 }
 
 impl Vertex {
-    const fn new(pos: Vec3, normal: Vec3) -> Self {
-        Self { pos, normal }
+    const fn new(pos: Vec3, normal: Vec3, uv: Vec2) -> Self {
+        Self { pos, normal, uv }
     }
 }
 
 static SHADER_BYTES: &[u8] = include_shader!("assets/frag-shader.pica");
 
 const VERTICES: &[Vertex] = &[
-    // First face (PZ)
-    // First triangle
-    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
-    // Second ace (MZ)
-    // First triangle
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
-    // Third ace (PX)
-    // First triangle
-    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
-    // Fourth ace (MX)
-    // First triangle
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
-    // Fith ace (PY)
-    // First triangle
-    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
-    // Sixth ace (MY)
-    // First triangle
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
-    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
-    // Second triangle
-    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
-    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, 0.5),
+        Vec3::new(0.0, 0.0, 1.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(0.0, 0.0, -1.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, -0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, -0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, 0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, -0.5),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, 0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, 0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, 0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, -0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(-1.0, 0.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, -0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, 0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, 0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, 0.5, -0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, 0.5, -0.5),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, -0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(1.0, 0.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, 0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(0.5, -0.5, 0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, 0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(0.0, 1.0),
+    ),
+    Vertex::new(
+        Vec3::new(-0.5, -0.5, -0.5),
+        Vec3::new(0.0, -1.0, 0.0),
+        Vec2::new(0.0, 0.0),
+    ),
 ];
 
 fn main() {
@@ -239,6 +378,7 @@ fn prepare_vbos<'a>(
 
     let reg0 = attrib::Register::new(0).unwrap();
     let reg1 = attrib::Register::new(1).unwrap();
+    let reg2 = attrib::Register::new(2).unwrap();
 
     attr_info
         .add_loader(reg0, attrib::Format::Float, 3)
@@ -246,6 +386,10 @@ fn prepare_vbos<'a>(
 
     attr_info
         .add_loader(reg1, attrib::Format::Float, 3)
+        .unwrap();
+
+    attr_info
+        .add_loader(reg2, attrib::Format::Float, 2)
         .unwrap();
 
     let buf_idx = buf_info.add(vbo_data, &attr_info).unwrap();

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -3,7 +3,7 @@ use citro3d::{
     attrib, buffer,
     light::{LightEnv, LightLutId, LutData, LutInput},
     material::{Color, Material},
-    math::{AspectRatio, ClipPlanes, FVec4, Matrix4, Projection, StereoDisplacement},
+    math::{AspectRatio, ClipPlanes, FVec3, FVec4, Matrix4, Projection, StereoDisplacement},
     render::{self, ClearFlags},
     shader, texenv,
 };
@@ -170,7 +170,7 @@ fn main() {
     let light = light_env.create_light().unwrap();
     let light = light_env.light_mut(light).unwrap();
     light.set_color(1.0, 1.0, 1.0);
-    light.set_position(FVec4::new(0.0, 0.0, -0.5, 1.0));
+    light.set_position(FVec3::new(0.0, 0.0, -0.5));
     let mut c = Matrix4::identity();
     let model_idx = program.get_uniform("modelView").unwrap();
     c.translate(0.0, 0.0, -2.0);

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -1,0 +1,218 @@
+#![feature(allocator_api)]
+use citro3d::{
+    attrib, buffer,
+    light::{LightEnv, LightLutId, LutData, LutInput},
+    material::{Color, Material},
+    math::{AspectRatio, ClipPlanes, FVec3, Matrix4, Projection, StereoDisplacement},
+    render::{self, ClearFlags},
+    shader, texenv,
+};
+use citro3d_macros::include_shader;
+use ctru::services::{
+    apt::Apt,
+    gfx::{Gfx, RawFrameBuffer, Screen, TopScreen3D},
+    hid::{Hid, KeyPad},
+    soc::Soc,
+};
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Vec3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl Vec3 {
+    const fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Vertex {
+    pos: Vec3,
+    normal: Vec3,
+}
+
+static VERTICES: &[Vertex] = &[
+    Vertex {
+        pos: Vec3::new(0.0, 0.5, -3.0),
+        normal: Vec3::new(0.0, 0.0, -1.0),
+    },
+    Vertex {
+        pos: Vec3::new(-0.5, -0.5, -3.0),
+        normal: Vec3::new(0.0, 1.0, -1.0),
+    },
+    Vertex {
+        pos: Vec3::new(0.5, -0.5, -3.0),
+        normal: Vec3::new(0.0, 0.0, -1.0),
+    },
+];
+static SHADER_BYTES: &[u8] = include_shader!("assets/frag-shader.pica");
+
+fn main() {
+    let mut soc = Soc::new().expect("failed to get SOC");
+    drop(soc.redirect_to_3dslink(true, true));
+
+    let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
+    let mut hid = Hid::new().expect("Couldn't obtain HID controller");
+    let apt = Apt::new().expect("Couldn't obtain APT controller");
+
+    let mut instance = citro3d::Instance::new().expect("failed to initialize Citro3D");
+
+    let top_screen = TopScreen3D::from(&gfx.top_screen);
+
+    let (mut top_left, mut top_right) = top_screen.split_mut();
+
+    let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
+    let mut top_left_target =
+        render::Target::new(width, height, top_left, None).expect("failed to create render target");
+
+    let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
+    let mut top_right_target = render::Target::new(width, height, top_right, None)
+        .expect("failed to create render target");
+
+    let mut bottom_screen = gfx.bottom_screen.borrow_mut();
+    let RawFrameBuffer { width, height, .. } = bottom_screen.raw_framebuffer();
+
+    let mut bottom_target = render::Target::new(width, height, bottom_screen, None)
+        .expect("failed to create bottom screen render target");
+
+    let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
+
+    let program = shader::Program::new(vertex_shader).unwrap();
+    instance.bind_program(&program);
+
+    let mut vbo_data = Vec::with_capacity_in(VERTICES.len(), ctru::linear::LinearAllocator);
+    vbo_data.extend_from_slice(VERTICES);
+
+    let mut buf_info = buffer::Info::new();
+    let (attr_info, vbo_data) = prepare_vbos(&mut buf_info, &vbo_data);
+    let light_env = instance.light_env_mut();
+    light_env.connect_lut(LightLutId::D0, LutInput::LightNormal, LutData::phong(30.0));
+    light_env.set_material(Material {
+        ambient: Some(Color::new(0.2, 0.2, 0.2)),
+        diffuse: Some(Color::new(0.4, 0.4, 0.4)),
+        specular0: Some(Color::new(0.8, 0.8, 0.8)),
+        ..Default::default()
+    });
+    let light = light_env.create_light().unwrap();
+    let light = light_env.light_mut(light).unwrap();
+    light.set_color(1.0, 1.0, 1.0);
+    light.set_position(FVec3::new(0.0, 0.0, -4.0));
+    let mut c = Matrix4::identity();
+    let model_idx = program.get_uniform("modelView").unwrap();
+    c.translate(0.0, 0.0, -4.0);
+    instance.bind_vertex_uniform(model_idx, &c);
+
+    // Configure the first fragment shading substage to just pass through the vertex color
+    // See https://www.opengl.org/sdk/docs/man2/xhtml/glTexEnv.xml for more insight
+    let stage0 = texenv::Stage::new(0).unwrap();
+    instance
+        .texenv(stage0)
+        .src(
+            texenv::Mode::BOTH,
+            texenv::Source::FragmentPrimaryColor,
+            Some(texenv::Source::FragmentSecondaryColor),
+            None,
+        )
+        .func(texenv::Mode::BOTH, texenv::CombineFunc::Add);
+
+    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+
+    while apt.main_loop() {
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::START) {
+            break;
+        }
+
+        instance.render_frame_with(|instance| {
+            let mut render_to = |target: &mut render::Target, projection| {
+                target.clear(ClearFlags::ALL, 0, 0);
+
+                instance
+                    .select_render_target(target)
+                    .expect("failed to set render target");
+
+                instance.bind_vertex_uniform(projection_uniform_idx, projection);
+
+                instance.set_attr_info(&attr_info);
+
+                instance.draw_arrays(buffer::Primitive::Triangles, vbo_data);
+            };
+
+            let Projections {
+                left_eye,
+                right_eye,
+                center,
+            } = calculate_projections();
+
+            render_to(&mut top_left_target, &left_eye);
+            render_to(&mut top_right_target, &right_eye);
+            render_to(&mut bottom_target, &center);
+        });
+    }
+}
+
+fn prepare_vbos<'a>(
+    buf_info: &'a mut buffer::Info,
+    vbo_data: &'a [Vertex],
+) -> (attrib::Info, buffer::Slice<'a>) {
+    // Configure attributes for use with the vertex shader
+    let mut attr_info = attrib::Info::new();
+
+    let reg0 = attrib::Register::new(0).unwrap();
+    let reg1 = attrib::Register::new(1).unwrap();
+
+    attr_info
+        .add_loader(reg0, attrib::Format::Float, 3)
+        .unwrap();
+
+    attr_info
+        .add_loader(reg1, attrib::Format::Float, 3)
+        .unwrap();
+
+    let buf_idx = buf_info.add(vbo_data, &attr_info).unwrap();
+
+    (attr_info, buf_idx)
+}
+
+struct Projections {
+    left_eye: Matrix4,
+    right_eye: Matrix4,
+    center: Matrix4,
+}
+
+fn calculate_projections() -> Projections {
+    // TODO: it would be cool to allow playing around with these parameters on
+    // the fly with D-pad, etc.
+    let slider_val = ctru::os::current_3d_slider_state();
+    let interocular_distance = slider_val / 2.0;
+
+    let vertical_fov = 40.0_f32.to_radians();
+    let screen_depth = 2.0;
+
+    let clip_planes = ClipPlanes {
+        near: 0.01,
+        far: 100.0,
+    };
+
+    let (left, right) = StereoDisplacement::new(interocular_distance, screen_depth);
+
+    let (left_eye, right_eye) =
+        Projection::perspective(vertical_fov, AspectRatio::TopScreen, clip_planes)
+            .stereo_matrices(left, right);
+
+    let center =
+        Projection::perspective(vertical_fov, AspectRatio::BottomScreen, clip_planes).into();
+
+    Projections {
+        left_eye,
+        right_eye,
+        center,
+    }
+}

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -1,7 +1,9 @@
 #![feature(allocator_api)]
+use std::f32::consts::PI;
+
 use citro3d::{
     attrib, buffer,
-    light::{FresnelSelector, LightEnv, LightLut, LightLutId, LutInput},
+    light::{FresnelSelector, LightEnv, LightLut, LightLutDistAtten, LightLutId, LutInput},
     material::{Color, Material},
     math::{AspectRatio, ClipPlanes, FVec3, FVec4, Matrix4, Projection, StereoDisplacement},
     render::{self, ClearFlags},
@@ -321,6 +323,11 @@ fn main() {
     let mut light = light_env.as_mut().light_mut(light).unwrap();
     light.as_mut().set_color(1.0, 1.0, 1.0);
     light.as_mut().set_position(FVec3::new(0.0, 0.0, -0.5));
+    light
+        .as_mut()
+        .set_distance_attenutation(Some(LightLutDistAtten::new(0.0..400.0, |d| {
+            (1.0 / (4.0 * PI * d * d)).min(1.0)
+        })));
     let mut c = Matrix4::identity();
     let model_idx = program.get_uniform("modelView").unwrap();
     c.translate(0.0, 0.0, -2.0);

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -36,27 +36,80 @@ struct Vertex {
     normal: Vec3,
 }
 
-static VERTICES: &[Vertex] = &[
-    Vertex {
-        pos: Vec3::new(0.0, 0.5, -3.0),
-        normal: Vec3::new(0.0, 0.0, -1.0),
-    },
-    Vertex {
-        pos: Vec3::new(-0.5, -0.5, -3.0),
-        normal: Vec3::new(0.0, 1.0, -1.0),
-    },
-    Vertex {
-        pos: Vec3::new(0.5, -0.5, -3.0),
-        normal: Vec3::new(0.0, 0.0, -1.0),
-    },
-];
+impl Vertex {
+    const fn new(pos: Vec3, normal: Vec3) -> Self {
+        Self { pos, normal }
+    }
+}
+
 static SHADER_BYTES: &[u8] = include_shader!("assets/frag-shader.pica");
+
+const VERTICES: &[Vertex] = &[
+    // First face (PZ)
+    // First triangle
+    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, 0.0, 1.0)),
+    // Second ace (MZ)
+    // First triangle
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, 0.0, -1.0)),
+    // Third ace (PX)
+    // First triangle
+    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(1.0, 0.0, 0.0)),
+    // Fourth ace (MX)
+    // First triangle
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(-1.0, 0.0, 0.0)),
+    // Fith ace (PY)
+    // First triangle
+    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(0.5, 0.5, 0.5), Vec3::new(0.0, 1.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, 0.5, -0.5), Vec3::new(0.0, 1.0, 0.0)),
+    // Sixth ace (MY)
+    // First triangle
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
+    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
+    // Second triangle
+    Vertex::new(Vec3::new(0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, 0.5), Vec3::new(0.0, -1.0, 0.0)),
+    Vertex::new(Vec3::new(-0.5, -0.5, -0.5), Vec3::new(0.0, -1.0, 0.0)),
+];
 
 fn main() {
     let mut soc = Soc::new().expect("failed to get SOC");
     drop(soc.redirect_to_3dslink(true, true));
 
-    let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
+    let gfx = Gfx::with_formats_shared(
+        ctru::services::gspgpu::FramebufferFormat::Rgba8,
+        ctru::services::gspgpu::FramebufferFormat::Rgba8,
+    )
+    .expect("Couldn't obtain GFX controller");
     let mut hid = Hid::new().expect("Couldn't obtain HID controller");
     let apt = Apt::new().expect("Couldn't obtain APT controller");
 
@@ -67,18 +120,33 @@ fn main() {
     let (mut top_left, mut top_right) = top_screen.split_mut();
 
     let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
-    let mut top_left_target =
-        render::Target::new(width, height, top_left, None).expect("failed to create render target");
+    let mut top_left_target = render::Target::new(
+        width,
+        height,
+        top_left,
+        Some(render::DepthFormat::Depth24Stencil8),
+    )
+    .expect("failed to create render target");
 
     let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
-    let mut top_right_target = render::Target::new(width, height, top_right, None)
-        .expect("failed to create render target");
+    let mut top_right_target = render::Target::new(
+        width,
+        height,
+        top_right,
+        Some(render::DepthFormat::Depth24Stencil8),
+    )
+    .expect("failed to create render target");
 
     let mut bottom_screen = gfx.bottom_screen.borrow_mut();
     let RawFrameBuffer { width, height, .. } = bottom_screen.raw_framebuffer();
 
-    let mut bottom_target = render::Target::new(width, height, bottom_screen, None)
-        .expect("failed to create bottom screen render target");
+    let mut bottom_target = render::Target::new(
+        width,
+        height,
+        bottom_screen,
+        Some(render::DepthFormat::Depth24Stencil8),
+    )
+    .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
     let vertex_shader = shader.get(0).unwrap();
@@ -95,17 +163,17 @@ fn main() {
     light_env.connect_lut(LightLutId::D0, LutInput::LightNormal, LutData::phong(30.0));
     light_env.set_material(Material {
         ambient: Some(Color::new(0.2, 0.2, 0.2)),
-        diffuse: Some(Color::new(0.4, 0.4, 0.4)),
+        diffuse: Some(Color::new(1.0, 0.4, 1.0)),
         specular0: Some(Color::new(0.8, 0.8, 0.8)),
         ..Default::default()
     });
     let light = light_env.create_light().unwrap();
     let light = light_env.light_mut(light).unwrap();
     light.set_color(1.0, 1.0, 1.0);
-    light.set_position(FVec3::new(0.0, 0.0, -4.0));
+    light.set_position(FVec3::new(0.0, 0.5, -3.0));
     let mut c = Matrix4::identity();
     let model_idx = program.get_uniform("modelView").unwrap();
-    c.translate(0.0, 0.0, -4.0);
+    c.translate(0.0, 0.0, -2.0);
     instance.bind_vertex_uniform(model_idx, &c);
 
     // Configure the first fragment shading substage to just pass through the vertex color
@@ -139,6 +207,7 @@ fn main() {
                     .expect("failed to set render target");
 
                 instance.bind_vertex_uniform(projection_uniform_idx, projection);
+                instance.bind_vertex_uniform(model_idx, &c);
 
                 instance.set_attr_info(&attr_info);
 
@@ -155,6 +224,9 @@ fn main() {
             render_to(&mut top_right_target, &right_eye);
             render_to(&mut bottom_target, &center);
         });
+        c.translate(0.0, 0.0, 2.0);
+        c.rotate_y(1.0f32.to_radians());
+        c.translate(0.0, 0.0, -2.0);
     }
 }
 

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -3,7 +3,7 @@ use citro3d::{
     attrib, buffer,
     light::{LightEnv, LightLutId, LutData, LutInput},
     material::{Color, Material},
-    math::{AspectRatio, ClipPlanes, FVec3, Matrix4, Projection, StereoDisplacement},
+    math::{AspectRatio, ClipPlanes, FVec4, Matrix4, Projection, StereoDisplacement},
     render::{self, ClearFlags},
     shader, texenv,
 };
@@ -170,7 +170,7 @@ fn main() {
     let light = light_env.create_light().unwrap();
     let light = light_env.light_mut(light).unwrap();
     light.set_color(1.0, 1.0, 1.0);
-    light.set_position(FVec3::new(0.0, 0.5, -3.0));
+    light.set_position(FVec4::new(0.0, 0.0, -0.5, 1.0));
     let mut c = Matrix4::identity();
     let model_idx = program.get_uniform("modelView").unwrap();
     c.translate(0.0, 0.0, -2.0);

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -1,7 +1,7 @@
 #![feature(allocator_api)]
 use citro3d::{
     attrib, buffer,
-    light::{LightEnv, LightLutId, LutData, LutInput},
+    light::{FresnelSelector, LightEnv, LightLutId, LutData, LutInput},
     material::{Color, Material},
     math::{AspectRatio, ClipPlanes, FVec3, FVec4, Matrix4, Projection, StereoDisplacement},
     render::{self, ClearFlags},
@@ -309,7 +309,7 @@ fn main() {
     light_env.as_mut().connect_lut(
         LightLutId::D0,
         LutInput::LightNormal,
-        LutData::from_fn(|i| i.powf(30.0), false),
+        LutData::from_fn(|v| v.powf(10.0), false),
     );
     light_env.as_mut().set_material(Material {
         ambient: Some(Color::new(0.2, 0.2, 0.2)),

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -19,6 +19,8 @@
 pub mod attrib;
 pub mod buffer;
 pub mod error;
+pub mod light;
+pub mod material;
 pub mod math;
 pub mod render;
 pub mod shader;
@@ -27,6 +29,7 @@ pub mod uniform;
 
 use std::cell::{OnceCell, RefMut};
 use std::fmt;
+use std::pin::Pin;
 use std::rc::Rc;
 
 use ctru::services::gfx::Screen;
@@ -47,6 +50,7 @@ pub mod macros {
 pub struct Instance {
     texenvs: [OnceCell<TexEnv>; texenv::TEXENV_COUNT],
     queue: Rc<RenderQueue>,
+    light_env: Pin<Box<light::LightEnv>>,
 }
 
 /// Representation of `citro3d`'s internal render queue. This is something that
@@ -79,6 +83,12 @@ impl Instance {
     #[doc(alias = "C3D_Init")]
     pub fn with_cmdbuf_size(size: usize) -> Result<Self> {
         if unsafe { citro3d_sys::C3D_Init(size) } {
+            let mut light_env = Pin::new(Box::new(light::LightEnv::new()));
+            unsafe {
+                // setup the light env slot, since this is a pointer copy it will stick around even with we swap
+                // out light_env later
+                citro3d_sys::C3D_LightEnvBind(light_env.as_raw_mut() as *mut _);
+            }
             Ok(Self {
                 texenvs: [
                     // thank goodness there's only six of them!
@@ -90,6 +100,7 @@ impl Instance {
                     OnceCell::new(),
                 ],
                 queue: Rc::new(RenderQueue),
+                light_env,
             })
         } else {
             Err(Error::FailedToInitialize)
@@ -207,6 +218,9 @@ impl Instance {
         unsafe {
             citro3d_sys::C3D_BindProgram(program.as_raw().cast_mut());
         }
+    }
+    pub fn light_env_mut(&mut self) -> &mut light::LightEnv {
+        &mut self.light_env
     }
 
     /// Bind a uniform to the given `index` in the vertex shader for the next draw call.

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -83,11 +83,11 @@ impl Instance {
     #[doc(alias = "C3D_Init")]
     pub fn with_cmdbuf_size(size: usize) -> Result<Self> {
         if unsafe { citro3d_sys::C3D_Init(size) } {
-            let mut light_env = Pin::new(Box::new(light::LightEnv::new()));
+            let mut light_env = Box::pin(light::LightEnv::new());
             unsafe {
                 // setup the light env slot, since this is a pointer copy it will stick around even with we swap
                 // out light_env later
-                citro3d_sys::C3D_LightEnvBind(light_env.as_raw_mut() as *mut _);
+                citro3d_sys::C3D_LightEnvBind(light_env.as_mut().as_raw_mut());
             }
             Ok(Self {
                 texenvs: [
@@ -219,8 +219,8 @@ impl Instance {
             citro3d_sys::C3D_BindProgram(program.as_raw().cast_mut());
         }
     }
-    pub fn light_env_mut(&mut self) -> &mut light::LightEnv {
-        &mut self.light_env
+    pub fn light_env_mut(&mut self) -> Pin<&mut light::LightEnv> {
+        self.light_env.as_mut()
     }
 
     /// Bind a uniform to the given `index` in the vertex shader for the next draw call.

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -161,6 +161,9 @@ impl Light {
 unsafe impl Send for Light {}
 unsafe impl Sync for Light {}
 
+unsafe impl Send for LightEnv {}
+unsafe impl Sync for LightEnv {}
+
 #[repr(transparent)]
 pub struct LutData(citro3d_sys::C3D_LightLut);
 

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -154,6 +154,14 @@ impl Light {
     pub fn set_color(&mut self, r: f32, g: f32, b: f32) {
         unsafe { citro3d_sys::C3D_LightColor(self.as_raw_mut(), r, g, b) }
     }
+    #[doc(alias = "C3D_LightEnable")]
+    pub fn set_enabled(&mut self, enabled: bool) {
+        unsafe { citro3d_sys::C3D_LightEnable(self.as_raw_mut(), enabled) }
+    }
+    #[doc(alias = "C3D_LightShadowEnable")]
+    pub fn set_shadow(&mut self, shadow: bool) {
+        unsafe { citro3d_sys::C3D_LightShadowEnable(self.as_raw_mut(), shadow) }
+    }
 }
 
 // Safety: I am 99% sure these are safe. That 1% is if citro3d does something weird I missed

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -1,0 +1,172 @@
+//!
+//!
+//! What does anything in this module mean? inspect this diagram: https://raw.githubusercontent.com/wwylele/misc-3ds-diagram/master/pica-pipeline.svg
+
+use std::{mem::MaybeUninit, pin::Pin};
+
+use crate::{material::Material, math::FVec3};
+
+#[derive(Default)]
+struct LightEnvStorage {
+    lights: [Option<Light>; 8],
+    luts: [Option<LutData>; 6],
+}
+
+pub struct LightEnv {
+    raw: citro3d_sys::C3D_LightEnv,
+    /// The actual light data pointed to by the lights element of `raw`
+    ///
+    /// Note this is `Pin` as well as `Box` as `raw` means we are _actually_ self-referential which
+    /// is horrible but the best bad option in this case
+    store: Pin<Box<LightEnvStorage>>,
+}
+
+pub struct Light(citro3d_sys::C3D_Light);
+
+impl Default for LightEnv {
+    fn default() -> Self {
+        let raw = unsafe {
+            let mut env = MaybeUninit::uninit();
+            citro3d_sys::C3D_LightEnvInit(env.as_mut_ptr());
+            env.assume_init()
+        };
+        Self {
+            raw,
+            store: Pin::new(Default::default()),
+        }
+    }
+}
+impl LightEnv {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn set_material(&mut self, mat: Material) {
+        let raw = mat.to_raw();
+        // Safety: This takes a pointer but it actually memcpy's it so this doesn't dangle
+        unsafe {
+            citro3d_sys::C3D_LightEnvMaterial(self.as_raw_mut() as *mut _, (&raw) as *const _);
+        }
+    }
+
+    pub fn lights(&self) -> [Option<&Light>; 8] {
+        core::array::from_fn(|i| self.store.lights[i].as_ref())
+    }
+
+    pub fn light_mut(&mut self, idx: usize) -> Option<&mut Light> {
+        self.store.lights[idx].as_mut()
+    }
+    pub fn create_light(&mut self) -> Option<usize> {
+        let idx = self
+            .lights()
+            .iter()
+            .enumerate()
+            .find(|(_, n)| n.is_none())
+            .map(|(n, _)| n)?;
+        let light = &mut self.store.lights[idx];
+        let env = &mut self.raw;
+        let r = unsafe { citro3d_sys::C3D_LightInit(light as *mut _ as *mut _, env as *mut _) };
+        assert!(r >= 0, "C3D_LightInit should only fail if there are no free light slots but we checked that already, how did this happen?");
+        assert_eq!(
+            r as usize, idx,
+            "citro3d chose a different light to us? this shouldn't be possible"
+        );
+        Some(idx)
+    }
+    ///
+    pub fn connect_lut(&mut self, id: LightLutId, input: LutInput, data: LutData) {
+        let idx = match id {
+            LightLutId::D0 => Some(0),
+            LightLutId::D1 => Some(1),
+            LightLutId::SpotLightAttenuation => None,
+            LightLutId::Fresnel => Some(2),
+            LightLutId::ReflectBlue => Some(3),
+            LightLutId::ReflectGreen => Some(4),
+            LightLutId::ReflectRed => Some(5),
+            LightLutId::DistanceAttenuation => None,
+        };
+        let lut = idx.map(|i| self.store.luts[i].insert(data));
+        let raw = &mut self.raw;
+        let lut = match lut {
+            Some(l) => (&mut l.0) as *mut _,
+            None => core::ptr::null_mut(),
+        };
+        unsafe {
+            citro3d_sys::C3D_LightEnvLut(raw, id as u32, input as u32, false, lut);
+        }
+    }
+
+    pub fn as_raw(&self) -> &citro3d_sys::C3D_LightEnv {
+        &self.raw
+    }
+
+    pub fn as_raw_mut(&mut self) -> &mut citro3d_sys::C3D_LightEnv {
+        &mut self.raw
+    }
+}
+
+impl Light {
+    fn from_raw_ref(l: &citro3d_sys::C3D_Light) -> &Self {
+        unsafe { (l as *const _ as *const Self).as_ref().unwrap() }
+    }
+    fn from_raw_mut(l: &mut citro3d_sys::C3D_Light) -> &mut Self {
+        unsafe { (l as *mut _ as *mut Self).as_mut().unwrap() }
+    }
+    fn as_raw(&self) -> &citro3d_sys::C3D_Light {
+        &self.0
+    }
+
+    fn as_raw_mut(&mut self) -> &mut citro3d_sys::C3D_Light {
+        &mut self.0
+    }
+    pub fn set_position(&mut self, mut p: FVec3) {
+        unsafe { citro3d_sys::C3D_LightPosition(self.as_raw_mut(), (&mut p.0) as *mut _) }
+    }
+    pub fn set_color(&mut self, r: f32, g: f32, b: f32) {
+        unsafe { citro3d_sys::C3D_LightColor(self.as_raw_mut(), r, g, b) }
+    }
+}
+
+#[repr(transparent)]
+pub struct LutData(citro3d_sys::C3D_LightLut);
+
+extern "C" fn c_powf(a: f32, b: f32) -> f32 {
+    a.powf(b)
+}
+
+impl LutData {
+    pub fn phong(shininess: f32) -> Self {
+        let lut = unsafe {
+            let mut lut = MaybeUninit::uninit();
+            citro3d_sys::LightLut_FromFunc(lut.as_mut_ptr(), Some(c_powf), shininess, false);
+            lut.assume_init()
+        };
+        Self(lut)
+    }
+}
+
+#[repr(u32)]
+pub enum LutInput {
+    CosPhi = ctru_sys::GPU_LUTINPUT_CP,
+    /// Light vector * normal
+    LightNormal = ctru_sys::GPU_LUTINPUT_LN,
+    /// normal * half vector
+    NormalHalf = ctru_sys::GPU_LUTINPUT_NH,
+    /// normal * view
+    NormalView = ctru_sys::GPU_LUTINPUT_NV,
+    /// light * spotlight
+    LightSpotLight = ctru_sys::GPU_LUTINPUT_SP,
+    /// view * half vector
+    ViewHalf = ctru_sys::GPU_LUTINPUT_VH,
+}
+
+#[repr(u32)]
+pub enum LightLutId {
+    D0 = ctru_sys::GPU_LUT_D0,
+    D1 = ctru_sys::GPU_LUT_D1,
+    SpotLightAttenuation = ctru_sys::GPU_LUT_SP,
+    Fresnel = ctru_sys::GPU_LUT_FR,
+    ReflectBlue = ctru_sys::GPU_LUT_RB,
+    ReflectGreen = ctru_sys::GPU_LUT_RG,
+    ReflectRed = ctru_sys::GPU_LUT_RR,
+    DistanceAttenuation = ctru_sys::GPU_LUT_DA,
+}

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -11,9 +11,28 @@
 //! For things like specular lighting we need to go a bit deeper
 //!
 //! # LUTS
-//! LUTS are lookup tables, in this case for the GPU. They are created ahead of time and stored in [`LutData`]'s,
-//! [`LutData::from_fn`] essentially memoises the given function with the input changing depending on what
+//! LUTS are lookup tables, in this case for the GPU. They are created ahead of time and stored in [`LightLut`]'s,
+//! [`LightLut::from_fn`] essentially memoises the given function with the input changing depending on what
 //! input it is bound to when setting it on the [`LightEnv`].
+//!
+//! ## Example
+//! Lets say we have this code
+//!
+//! ```
+//! # use citro3d::{Instance, light::{LightLutId, LightInput, LightLut}};
+//! let mut inst = Instance::new();
+//! let mut env = inst.light_env_mut();
+//! env.as_mut().connect_lut(
+//!     LutInputId::D0,
+//!     LutInput::NormalView,
+//!     LightLut::from_fn(|x| x.powf(10.0)),
+//! );
+//! ```
+//!
+//! This places the LUT in `D0` (refer to [the diagram][hardware]) and connects the input wire as the dot product
+//! of the normal and view vectors. `x` is effectively the dot product of the normal and view for every vertex and
+//! the return of the closure goes out on the corresponding wire
+//! (which in the case of `D0` is used for specular lighting after being combined with with specular0)
 //!
 //!
 //!
@@ -278,6 +297,9 @@ unsafe impl Sync for Light {}
 unsafe impl Send for LightEnv {}
 unsafe impl Sync for LightEnv {}
 
+/// Lookup table for light data
+///
+/// For more refer to the module documentation
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
 pub struct LightLut(citro3d_sys::C3D_LightLut);
@@ -303,6 +325,7 @@ extern "C" fn c_powf(a: f32, b: f32) -> f32 {
 type LutArray = [u32; 256];
 
 impl LightLut {
+    /// Create a LUT by memoizing a function
     pub fn from_fn(mut f: impl FnMut(f32) -> f32, negative: bool) -> Self {
         const LUT_BUF_SZ: usize = 512;
         let base: i32 = 128;
@@ -351,7 +374,7 @@ impl LightLut {
     }
 }
 
-/// This is used to decide what the input should be to a [`LutData`]
+/// This is used to decide what the input should be to a [`LightLut`]
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[repr(u32)]
 pub enum LutInput {

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -2,7 +2,9 @@
 //!
 //! What does anything in this module mean? inspect this diagram: https://raw.githubusercontent.com/wwylele/misc-3ds-diagram/master/pica-pipeline.svg
 
-use std::{mem::MaybeUninit, pin::Pin};
+use std::{marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
+
+use pin_array::PinArray;
 
 use crate::{
     material::Material,
@@ -27,12 +29,29 @@ impl LightIndex {
         assert!(idx < NB_LIGHTS);
         Self(idx as u8)
     }
+    pub fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[derive(Default)]
+struct LightLutStorage {
+    spot: Option<LutData>,
+    diffuse_atten: Option<LutData>,
+    _pin: PhantomPinned,
 }
 
 #[derive(Default)]
 struct LightEnvStorage {
     lights: [Option<Light>; NB_LIGHTS],
     luts: [Option<LutData>; 6],
+    _pin: PhantomPinned,
+}
+
+impl LightEnvStorage {
+    fn lights_mut(self: Pin<&mut Self>) -> Pin<&mut [Option<Light>; NB_LIGHTS]> {
+        unsafe { Pin::map_unchecked_mut(self, |s| &mut s.lights) }
+    }
 }
 
 pub struct LightEnv {
@@ -41,21 +60,30 @@ pub struct LightEnv {
     ///
     /// Note this is `Pin` as well as `Box` as `raw` means we are _actually_ self-referential which
     /// is horrible but the best bad option in this case
-    store: Pin<Box<LightEnvStorage>>,
+    lights: LightArray,
+    luts: [Option<LutData>; 6],
+    _pin: PhantomPinned,
 }
 
-pub struct Light(citro3d_sys::C3D_Light);
+pub struct Light {
+    raw: citro3d_sys::C3D_Light,
+    spot: Option<LutData>,
+    diffuse_atten: Option<LutData>,
+    _pin: PhantomPinned,
+}
 
 impl Default for LightEnv {
     fn default() -> Self {
         let raw = unsafe {
-            let mut env = MaybeUninit::uninit();
+            let mut env = MaybeUninit::zeroed();
             citro3d_sys::C3D_LightEnvInit(env.as_mut_ptr());
             env.assume_init()
         };
         Self {
             raw,
-            store: Pin::new(Default::default()),
+            lights: Default::default(),
+            luts: Default::default(),
+            _pin: Default::default(),
         }
     }
 }
@@ -63,7 +91,7 @@ impl LightEnv {
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn set_material(&mut self, mat: Material) {
+    pub fn set_material(self: Pin<&mut Self>, mat: Material) {
         let raw = mat.to_raw();
         // Safety: This takes a pointer but it actually memcpy's it so this doesn't dangle
         unsafe {
@@ -71,14 +99,21 @@ impl LightEnv {
         }
     }
 
-    pub fn lights(&self) -> [Option<&Light>; 8] {
-        core::array::from_fn(|i| self.store.lights[i].as_ref())
+    pub fn lights(&self) -> &LightArray {
+        &self.lights
     }
 
-    pub fn light_mut(&mut self, idx: LightIndex) -> Option<&mut Light> {
-        self.store.lights[idx.0 as usize].as_mut()
+    pub fn lights_mut(self: Pin<&mut Self>) -> Pin<&mut LightArray> {
+        unsafe { self.map_unchecked_mut(|s| &mut s.lights) }
     }
-    pub fn create_light(&mut self) -> Option<LightIndex> {
+
+    pub fn light_mut(self: Pin<&mut Self>, idx: LightIndex) -> Option<Pin<&mut Light>> {
+        self.lights_mut()
+            .get_pin(idx.0 as usize)
+            .unwrap()
+            .as_pin_mut()
+    }
+    pub fn create_light(mut self: Pin<&mut Self>) -> Option<LightIndex> {
         let idx = self
             .lights()
             .iter()
@@ -86,14 +121,23 @@ impl LightEnv {
             .find(|(_, n)| n.is_none())
             .map(|(n, _)| n)?;
 
-        self.store.lights[idx] = Some(Light(unsafe { MaybeUninit::zeroed().assume_init() }));
+        self.as_mut()
+            .lights_mut()
+            .get_pin(idx)
+            .unwrap()
+            .set(Some(Light::new(unsafe {
+                MaybeUninit::zeroed().assume_init()
+            })));
 
-        let r = unsafe {
-            citro3d_sys::C3D_LightInit(
-                self.store.lights[idx].as_mut().unwrap().as_raw_mut(),
-                self.as_raw_mut() as *mut _,
-            )
+        let target = unsafe {
+            self.as_mut()
+                .lights_mut()
+                .get_pin(idx)
+                .unwrap()
+                .map_unchecked_mut(|p| p.as_mut().unwrap())
         };
+        let r =
+            unsafe { citro3d_sys::C3D_LightInit(target.as_raw_mut(), self.as_raw_mut() as *mut _) };
         assert!(r >= 0, "C3D_LightInit should only fail if there are no free light slots but we checked that already, how did this happen?");
         assert_eq!(
             r as usize, idx,
@@ -102,7 +146,7 @@ impl LightEnv {
         Some(LightIndex::new(idx))
     }
     ///
-    pub fn connect_lut(&mut self, id: LightLutId, input: LutInput, data: LutData) {
+    pub fn connect_lut(mut self: Pin<&mut Self>, id: LightLutId, input: LutInput, data: LutData) {
         let idx = match id {
             LightLutId::D0 => Some(0),
             LightLutId::D1 => Some(1),
@@ -113,11 +157,17 @@ impl LightEnv {
             LightLutId::ReflectRed => Some(5),
             LightLutId::DistanceAttenuation => None,
         };
-        let lut = idx.map(|i| self.store.luts[i].insert(data));
-        let raw = &mut self.raw;
-        let lut = match lut {
-            Some(l) => (&mut l.0) as *mut _,
-            None => core::ptr::null_mut(),
+        let (raw, lut) = unsafe {
+            // this is needed to do structural borrowing as otherwise
+            // the compiler rejects the reborrow needed with the pin
+            let me = self.as_mut().get_unchecked_mut();
+            let lut = idx.map(|i| me.luts[i].insert(data));
+            let raw = &mut me.raw;
+            let lut = match lut {
+                Some(l) => (&mut l.0) as *mut _,
+                None => core::ptr::null_mut(),
+            };
+            (raw, lut)
         };
         unsafe {
             citro3d_sys::C3D_LightEnvLut(raw, id as u32, input as u32, false, lut);
@@ -128,12 +178,21 @@ impl LightEnv {
         &self.raw
     }
 
-    pub fn as_raw_mut(&mut self) -> &mut citro3d_sys::C3D_LightEnv {
-        &mut self.raw
+    pub fn as_raw_mut(self: Pin<&mut Self>) -> &mut citro3d_sys::C3D_LightEnv {
+        unsafe { &mut self.get_unchecked_mut().raw }
     }
 }
 
 impl Light {
+    fn new(raw: citro3d_sys::C3D_Light) -> Self {
+        Self {
+            raw,
+            spot: Default::default(),
+            diffuse_atten: Default::default(),
+            _pin: Default::default(),
+        }
+    }
+
     fn from_raw_ref(l: &citro3d_sys::C3D_Light) -> &Self {
         unsafe { (l as *const _ as *const Self).as_ref().unwrap() }
     }
@@ -141,25 +200,25 @@ impl Light {
         unsafe { (l as *mut _ as *mut Self).as_mut().unwrap() }
     }
     fn as_raw(&self) -> &citro3d_sys::C3D_Light {
-        &self.0
+        &self.raw
     }
 
-    fn as_raw_mut(&mut self) -> &mut citro3d_sys::C3D_Light {
-        &mut self.0
+    fn as_raw_mut(self: Pin<&mut Self>) -> &mut citro3d_sys::C3D_Light {
+        unsafe { &mut self.get_unchecked_mut().raw }
     }
-    pub fn set_position(&mut self, p: FVec3) {
+    pub fn set_position(self: Pin<&mut Self>, p: FVec3) {
         let mut p = FVec4::new(p.x(), p.y(), p.z(), 1.0);
         unsafe { citro3d_sys::C3D_LightPosition(self.as_raw_mut(), &mut p.0) }
     }
-    pub fn set_color(&mut self, r: f32, g: f32, b: f32) {
+    pub fn set_color(self: Pin<&mut Self>, r: f32, g: f32, b: f32) {
         unsafe { citro3d_sys::C3D_LightColor(self.as_raw_mut(), r, g, b) }
     }
     #[doc(alias = "C3D_LightEnable")]
-    pub fn set_enabled(&mut self, enabled: bool) {
+    pub fn set_enabled(self: Pin<&mut Self>, enabled: bool) {
         unsafe { citro3d_sys::C3D_LightEnable(self.as_raw_mut(), enabled) }
     }
     #[doc(alias = "C3D_LightShadowEnable")]
-    pub fn set_shadow(&mut self, shadow: bool) {
+    pub fn set_shadow(self: Pin<&mut Self>, shadow: bool) {
         unsafe { citro3d_sys::C3D_LightShadowEnable(self.as_raw_mut(), shadow) }
     }
 }
@@ -216,3 +275,5 @@ pub enum LightLutId {
     ReflectRed = ctru_sys::GPU_LUT_RR,
     DistanceAttenuation = ctru_sys::GPU_LUT_DA,
 }
+
+type LightArray = PinArray<Option<Light>, NB_LIGHTS>;

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -209,8 +209,8 @@ impl LightEnv {
             unsafe {
                 citro3d_sys::C3D_LightEnvLut(
                     &mut me.raw,
-                    id as u32,
-                    input as u32,
+                    id as u8,
+                    input as u8,
                     false,
                     std::ptr::null_mut(),
                 );
@@ -233,7 +233,7 @@ impl LightEnv {
             (raw, lut)
         };
         unsafe {
-            citro3d_sys::C3D_LightEnvLut(raw, id as u32, input as u32, false, lut);
+            citro3d_sys::C3D_LightEnvLut(raw, id as u8, input as u8, false, lut);
         }
     }
     pub fn set_fresnel(mut self: Pin<&mut Self>, sel: FresnelSelector) {
@@ -416,7 +416,7 @@ impl LightLutDistAtten {
 
 /// This is used to decide what the input should be to a [`LightLut`]
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum LutInput {
     CosPhi = ctru_sys::GPU_LUTINPUT_CP,
     /// Dot product of the light and normal vectors
@@ -432,7 +432,7 @@ pub enum LutInput {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum LightLutId {
     D0 = ctru_sys::GPU_LUT_D0,
     D1 = ctru_sys::GPU_LUT_D1,
@@ -444,7 +444,7 @@ pub enum LightLutId {
     DistanceAttenuation = ctru_sys::GPU_LUT_DA,
 }
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum FresnelSelector {
     /// No fresnel selection
     None = ctru_sys::GPU_NO_FRESNEL,

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -156,6 +156,11 @@ impl Light {
     }
 }
 
+// Safety: I am 99% sure these are safe. That 1% is if citro3d does something weird I missed
+// which is not impossible
+unsafe impl Send for Light {}
+unsafe impl Sync for Light {}
+
 #[repr(transparent)]
 pub struct LutData(citro3d_sys::C3D_LightLut);
 

--- a/citro3d/src/light.rs
+++ b/citro3d/src/light.rs
@@ -4,7 +4,10 @@
 
 use std::{mem::MaybeUninit, pin::Pin};
 
-use crate::{material::Material, math::FVec4};
+use crate::{
+    material::Material,
+    math::{FVec3, FVec4},
+};
 
 #[derive(Default)]
 struct LightEnvStorage {
@@ -124,8 +127,9 @@ impl Light {
     fn as_raw_mut(&mut self) -> &mut citro3d_sys::C3D_Light {
         &mut self.0
     }
-    pub fn set_position(&mut self, mut p: FVec4) {
-        unsafe { citro3d_sys::C3D_LightPosition(self.as_raw_mut(), (&mut p.0) as *mut _) }
+    pub fn set_position(&mut self, p: FVec3) {
+        let mut p = FVec4::new(p.x(), p.y(), p.z(), 1.0);
+        unsafe { citro3d_sys::C3D_LightPosition(self.as_raw_mut(), &mut p.0) }
     }
     pub fn set_color(&mut self, r: f32, g: f32, b: f32) {
         unsafe { citro3d_sys::C3D_LightColor(self.as_raw_mut(), r, g, b) }

--- a/citro3d/src/material.rs
+++ b/citro3d/src/material.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Material {
+    pub ambient: Option<Color>,
+    pub diffuse: Option<Color>,
+    pub specular0: Option<Color>,
+    pub specular1: Option<Color>,
+    pub emission: Option<Color>,
+}
+impl Material {
+    pub fn to_raw(self) -> citro3d_sys::C3D_Material {
+        citro3d_sys::C3D_Material {
+            ambient: self.ambient.unwrap_or_default().to_parts(),
+            diffuse: self.diffuse.unwrap_or_default().to_parts(),
+            specular0: self.specular0.unwrap_or_default().to_parts(),
+            specular1: self.specular1.unwrap_or_default().to_parts(),
+            emission: self.emission.unwrap_or_default().to_parts(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Color {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+impl Color {
+    pub fn new(r: f32, g: f32, b: f32) -> Self {
+        Self { r, g, b }
+    }
+    pub fn to_parts(self) -> [f32; 3] {
+        [self.r, self.g, self.b]
+    }
+}

--- a/citro3d/src/material.rs
+++ b/citro3d/src/material.rs
@@ -9,15 +9,16 @@ pub struct Material {
 impl Material {
     pub fn to_raw(self) -> citro3d_sys::C3D_Material {
         citro3d_sys::C3D_Material {
-            ambient: self.ambient.unwrap_or_default().to_parts(),
-            diffuse: self.diffuse.unwrap_or_default().to_parts(),
-            specular0: self.specular0.unwrap_or_default().to_parts(),
-            specular1: self.specular1.unwrap_or_default().to_parts(),
-            emission: self.emission.unwrap_or_default().to_parts(),
+            ambient: self.ambient.unwrap_or_default().to_parts_bgr(),
+            diffuse: self.diffuse.unwrap_or_default().to_parts_bgr(),
+            specular0: self.specular0.unwrap_or_default().to_parts_bgr(),
+            specular1: self.specular1.unwrap_or_default().to_parts_bgr(),
+            emission: self.emission.unwrap_or_default().to_parts_bgr(),
         }
     }
 }
 
+/// RGB color in linear space ([0, 1])
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Color {
     pub r: f32,
@@ -29,7 +30,12 @@ impl Color {
     pub fn new(r: f32, g: f32, b: f32) -> Self {
         Self { r, g, b }
     }
-    pub fn to_parts(self) -> [f32; 3] {
-        [self.r, self.g, self.b]
+    /// Split into BGR ordered parts
+    ///
+    /// # Reason for existence
+    /// The C version of [`Material`] expects colours in BGR order (don't ask why it is beyond my comprehension)
+    /// so we have to reorder when converting
+    pub fn to_parts_bgr(self) -> [f32; 3] {
+        [self.b, self.g, self.r]
     }
 }


### PR DESCRIPTION
This adds support for the lighting API. 

It's a bit rough, I don't _currently_ have a 3ds to test it on but the pre-rebase version is used as part of our bevy 3ds port so I'm pretty confident it works alright.

It does have an example which should render a rotating purple cube with specular lighting, again I can only test this in emulation right now.

The implementation is... complex. The citro3d internals here are a minefield of backpointers, the wrapper makes liberal use of `Pin` to try and avoid allocating where possible (the user is of course free to put `LightEnv` on the heap if they don't want to deal with the mess) as well as faithfully portraying the semantics of the C API.

The way to actually use it is a bit convoluted, basically you should use `light_env_mut` on `Instance`, technically you should be able to `mem::swap` on that and it'll bind a different `LightEnv`, I'm not sure how or if this should be a part of the documented API.

Note this currently does NOT include spotlight support, it only supports point lights.