### PR TITLE
Add const qualifier to ctru-sys gx functions

### DIFF
--- a/citro3d-sys/src/gx.rs
+++ b/citro3d-sys/src/gx.rs
@@ -4,31 +4,31 @@
 use ctru_sys::{GX_TRANSFER_FORMAT, GX_TRANSFER_SCALE};
 
 #[inline]
-pub fn GX_TRANSFER_FLIP_VERT(flip: bool) -> u32 {
+pub const fn GX_TRANSFER_FLIP_VERT(flip: bool) -> u32 {
     flip as u32
 }
 
 #[inline]
-pub fn GX_TRANSFER_OUT_TILED(tiled: bool) -> u32 {
+pub const fn GX_TRANSFER_OUT_TILED(tiled: bool) -> u32 {
     (tiled as u32) << 1
 }
 
 #[inline]
-pub fn GX_TRANSFER_RAW_COPY(raw_copy: bool) -> u32 {
+pub const fn GX_TRANSFER_RAW_COPY(raw_copy: bool) -> u32 {
     (raw_copy as u32) << 3
 }
 
 #[inline]
-pub fn GX_TRANSFER_IN_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
+pub const fn GX_TRANSFER_IN_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
     (format as u32) << 8
 }
 
 #[inline]
-pub fn GX_TRANSFER_OUT_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
+pub const fn GX_TRANSFER_OUT_FORMAT(format: GX_TRANSFER_FORMAT) -> u32 {
     (format as u32) << 12
 }
 
 #[inline]
-pub fn GX_TRANSFER_SCALING(scale: GX_TRANSFER_SCALE) -> u32 {
+pub const fn GX_TRANSFER_SCALING(scale: GX_TRANSFER_SCALE) -> u32 {
     (scale as u32) << 24
 }


### PR DESCRIPTION
Not a huge change here. Just lets you use these functions in const contexts, which is needed since these are basically C macro replacements