### PR TITLE
Require frame-long timelines for all items used during a render pass

### DIFF
--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -30,18 +30,14 @@ pub mod texenv;
 pub mod texture;
 pub mod uniform;
 
-use std::cell::{OnceCell, RefMut};
+use std::cell::RefMut;
 use std::fmt;
-use std::pin::Pin;
 use std::rc::Rc;
 
 use ctru::services::gfx::Screen;
 pub use error::{Error, Result};
 
-use self::buffer::{Index, Indices};
-use self::light::LightEnv;
-use self::texenv::TexEnv;
-use self::uniform::Uniform;
+use crate::render::RenderPass;
 
 pub mod macros {
     //! Helper macros for working with shaders.
@@ -54,21 +50,19 @@ mod private {
     impl Sealed for u16 {}
 }
 
-/// The single instance for using `citro3d`. This is the base type that an application
-/// should instantiate to use this library.
-#[non_exhaustive]
-#[must_use]
-pub struct Instance {
-    texenvs: [OnceCell<TexEnv>; texenv::TEXENV_COUNT],
-    queue: Rc<RenderQueue>,
-    light_env: Option<Pin<Box<LightEnv>>>,
-}
-
 /// Representation of `citro3d`'s internal render queue. This is something that
 /// lives in the global context, but it keeps references to resources that are
 /// used for rendering, so it's useful for us to have something to represent its
 /// lifetime.
 struct RenderQueue;
+
+/// The single instance for using `citro3d`. This is the base type that an application
+/// should instantiate to use this library.
+#[non_exhaustive]
+#[must_use]
+pub struct Instance {
+    queue: Rc<RenderQueue>,
+}
 
 impl fmt::Debug for Instance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -95,17 +89,7 @@ impl Instance {
     pub fn with_cmdbuf_size(size: usize) -> Result<Self> {
         if unsafe { citro3d_sys::C3D_Init(size) } {
             Ok(Self {
-                texenvs: [
-                    // thank goodness there's only six of them!
-                    OnceCell::new(),
-                    OnceCell::new(),
-                    OnceCell::new(),
-                    OnceCell::new(),
-                    OnceCell::new(),
-                    OnceCell::new(),
-                ],
                 queue: Rc::new(RenderQueue),
-                light_env: None,
             })
         } else {
             Err(Error::FailedToInitialize)
@@ -130,30 +114,15 @@ impl Instance {
         render::Target::new(width, height, screen, depth_format, Rc::clone(&self.queue))
     }
 
-    /// Select the given render target for drawing the frame. This must be called
-    /// as pare of a render call (i.e. within the call to
-    /// [`render_frame_with`](Self::render_frame_with)).
-    ///
-    /// # Errors
-    ///
-    /// Fails if the given target cannot be used for drawing, or called outside
-    /// the context of a frame render.
-    #[doc(alias = "C3D_FrameDrawOn")]
-    pub fn select_render_target(&mut self, target: &render::Target<'_>) -> Result<()> {
-        let _ = self;
-        if unsafe { citro3d_sys::C3D_FrameDrawOn(target.as_raw()) } {
-            Ok(())
-        } else {
-            Err(Error::InvalidRenderTarget)
-        }
-    }
-
     /// Render a frame. The passed in function/closure can mutate the instance,
     /// such as to [select a render target](Self::select_render_target)
     /// or [bind a new shader program](Self::bind_program).
     #[doc(alias = "C3D_FrameBegin")]
     #[doc(alias = "C3D_FrameEnd")]
-    pub fn render_frame_with(&mut self, f: impl FnOnce(&mut Self)) {
+    pub fn render_frame_with<'istance: 'frame, 'frame>(
+        &'istance mut self,
+        f: impl FnOnce(RenderPass<'frame>) -> RenderPass<'frame>,
+    ) {
         unsafe {
             citro3d_sys::C3D_FrameBegin(
                 // TODO: begin + end flags should be configurable
@@ -161,187 +130,14 @@ impl Instance {
             );
         }
 
-        f(self);
+        let pass = f(RenderPass::new(self));
 
         unsafe {
             citro3d_sys::C3D_FrameEnd(0);
         }
-    }
 
-    /// Get the buffer info being used, if it exists. Note that the resulting
-    /// [`buffer::Info`] is copied from the one currently in use.
-    #[doc(alias = "C3D_GetBufInfo")]
-    pub fn buffer_info(&self) -> Option<buffer::Info> {
-        let raw = unsafe { citro3d_sys::C3D_GetBufInfo() };
-        buffer::Info::copy_from(raw)
-    }
-
-    /// Set the buffer info to use for any following draw calls.
-    #[doc(alias = "C3D_SetBufInfo")]
-    pub fn set_buffer_info(&mut self, buffer_info: &buffer::Info) {
-        let raw: *const _ = &buffer_info.0;
-        // SAFETY: C3D_SetBufInfo actually copies the pointee instead of mutating it.
-        unsafe { citro3d_sys::C3D_SetBufInfo(raw.cast_mut()) };
-    }
-
-    /// Get the attribute info being used, if it exists. Note that the resulting
-    /// [`attrib::Info`] is copied from the one currently in use.
-    #[doc(alias = "C3D_GetAttrInfo")]
-    pub fn attr_info(&self) -> Option<attrib::Info> {
-        let raw = unsafe { citro3d_sys::C3D_GetAttrInfo() };
-        attrib::Info::copy_from(raw)
-    }
-
-    /// Set the attribute info to use for any following draw calls.
-    #[doc(alias = "C3D_SetAttrInfo")]
-    pub fn set_attr_info(&mut self, attr_info: &attrib::Info) {
-        let raw: *const _ = &attr_info.0;
-        // SAFETY: C3D_SetAttrInfo actually copies the pointee instead of mutating it.
-        unsafe { citro3d_sys::C3D_SetAttrInfo(raw.cast_mut()) };
-    }
-
-    /// Render primitives from the current vertex array buffer.
-    #[doc(alias = "C3D_DrawArrays")]
-    pub fn draw_arrays(&mut self, primitive: buffer::Primitive, vbo_data: buffer::Slice) {
-        self.set_buffer_info(vbo_data.info());
-
-        // TODO: should we also require the attrib info directly here?
-        unsafe {
-            citro3d_sys::C3D_DrawArrays(
-                primitive as ctru_sys::GPU_Primitive_t,
-                vbo_data.index(),
-                vbo_data.len(),
-            );
-        }
-    }
-    /// Indexed drawing
-    ///
-    /// Draws the vertices in `buf` indexed by `indices`. `indices` must be linearly allocated
-    ///
-    /// # Safety
-    // TODO: #41 might be able to solve this:
-    /// If `indices` goes out of scope before the current frame ends it will cause a
-    /// use-after-free (possibly by the GPU).
-    ///
-    /// # Panics
-    ///
-    /// If the given index buffer is too long to have its length converted to `i32`.
-    #[doc(alias = "C3D_DrawElements")]
-    pub unsafe fn draw_elements<I: Index>(
-        &mut self,
-        primitive: buffer::Primitive,
-        vbo_data: buffer::Slice,
-        indices: &Indices<'_, I>,
-    ) {
-        self.set_buffer_info(vbo_data.info());
-
-        let indices = &indices.buffer;
-        let elements = indices.as_ptr().cast();
-
-        unsafe {
-            citro3d_sys::C3D_DrawElements(
-                primitive as ctru_sys::GPU_Primitive_t,
-                indices.len().try_into().unwrap(),
-                // flag bit for short or byte
-                I::TYPE,
-                elements,
-            );
-        }
-    }
-
-    /// Use the given [`shader::Program`] for subsequent draw calls.
-    pub fn bind_program(&mut self, program: &shader::Program) {
-        // SAFETY: AFAICT C3D_BindProgram just copies pointers from the given program,
-        // instead of mutating the pointee in any way that would cause UB
-        unsafe {
-            citro3d_sys::C3D_BindProgram(program.as_raw().cast_mut());
-        }
-    }
-
-    /// Binds a new [`LightEnv`], returning the previous one (if present).
-    pub fn bind_light_env(
-        &mut self,
-        new_env: Option<Pin<Box<LightEnv>>>,
-    ) -> Option<Pin<Box<LightEnv>>> {
-        let old_env = self.light_env.take();
-        self.light_env = new_env;
-
-        unsafe {
-            // setup the light env slot, since this is a pointer copy it will stick around even with we swap
-            // out light_env later
-            citro3d_sys::C3D_LightEnvBind(
-                self.light_env
-                    .as_mut()
-                    .map_or(std::ptr::null_mut(), |env| env.as_mut().as_raw_mut()),
-            );
-        }
-
-        old_env
-    }
-
-    pub fn light_env(&self) -> Option<Pin<&LightEnv>> {
-        self.light_env.as_ref().map(|env| env.as_ref())
-    }
-
-    pub fn light_env_mut(&mut self) -> Option<Pin<&mut LightEnv>> {
-        self.light_env.as_mut().map(|env| env.as_mut())
-    }
-
-    /// Bind a uniform to the given `index` in the vertex shader for the next draw call.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let _runner = test_runner::GdbRunner::default();
-    /// # use citro3d::uniform;
-    /// # use citro3d::math::Matrix4;
-    /// #
-    /// # let mut instance = citro3d::Instance::new().unwrap();
-    /// let idx = uniform::Index::from(0);
-    /// let mtx = Matrix4::identity();
-    /// instance.bind_vertex_uniform(idx, &mtx);
-    /// ```
-    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
-        uniform.into().bind(self, shader::Type::Vertex, index);
-    }
-
-    /// Bind a uniform to the given `index` in the geometry shader for the next draw call.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # let _runner = test_runner::GdbRunner::default();
-    /// # use citro3d::uniform;
-    /// # use citro3d::math::Matrix4;
-    /// #
-    /// # let mut instance = citro3d::Instance::new().unwrap();
-    /// let idx = uniform::Index::from(0);
-    /// let mtx = Matrix4::identity();
-    /// instance.bind_geometry_uniform(idx, &mtx);
-    /// ```
-    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
-        uniform.into().bind(self, shader::Type::Geometry, index);
-    }
-
-    /// Retrieve the [`TexEnv`] for the given stage, initializing it first if necessary.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use citro3d::texenv;
-    /// # let _runner = test_runner::GdbRunner::default();
-    /// # let mut instance = citro3d::Instance::new().unwrap();
-    /// let stage0 = texenv::Stage::new(0).unwrap();
-    /// let texenv0 = instance.texenv(stage0);
-    /// ```
-    #[doc(alias = "C3D_GetTexEnv")]
-    #[doc(alias = "C3D_TexEnvInit")]
-    pub fn texenv(&mut self, stage: texenv::Stage) -> &mut texenv::TexEnv {
-        let texenv = &mut self.texenvs[stage.0];
-        texenv.get_or_init(|| TexEnv::new(stage));
-        // We have to do this weird unwrap to get a mutable reference,
-        // since there is no `get_mut_or_init` or equivalent
-        texenv.get_mut().unwrap()
+        // Explicit drop after FrameEnd (when the GPU command buffer is flushed).
+        drop(pass);
     }
 }
 

--- a/citro3d/src/render.rs
+++ b/citro3d/src/render.rs
@@ -1,7 +1,9 @@
 //! This module provides render target types and options for controlling transfer
 //! of data to the GPU, including the format of color and depth data to be rendered.
 
-use std::cell::RefMut;
+use std::cell::{OnceCell, RefMut};
+use std::marker::PhantomData;
+use std::pin::Pin;
 use std::rc::Rc;
 
 use citro3d_sys::{
@@ -11,10 +13,61 @@ use ctru::services::gfx::Screen;
 use ctru::services::gspgpu::FramebufferFormat;
 use ctru_sys::{GPU_COLORBUF, GPU_DEPTHBUF};
 
-use crate::{Error, RenderQueue, Result};
+use crate::{
+    Error, Instance, RenderQueue, Result, attrib,
+    buffer::{self, Index, Indices},
+    light::LightEnv,
+    shader,
+    texenv::{self, TexEnv},
+    uniform::{self, Uniform},
+};
 
 pub mod effect;
 mod transfer;
+
+bitflags::bitflags! {
+    /// Indicate whether color, depth buffer, or both values should be cleared.
+    #[doc(alias = "C3D_ClearBits")]
+    pub struct ClearFlags: u8 {
+        /// Clear the color of the render target.
+        const COLOR = citro3d_sys::C3D_CLEAR_COLOR;
+        /// Clear the depth buffer value of the render target.
+        const DEPTH = citro3d_sys::C3D_CLEAR_DEPTH;
+        /// Clear both color and depth buffer values of the render target.
+        const ALL = citro3d_sys::C3D_CLEAR_ALL;
+    }
+}
+
+/// The color format to use when rendering on the GPU.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+#[doc(alias = "GPU_COLORBUF")]
+pub enum ColorFormat {
+    /// 8-bit Red + 8-bit Green + 8-bit Blue + 8-bit Alpha.
+    RGBA8 = ctru_sys::GPU_RB_RGBA8,
+    /// 8-bit Red + 8-bit Green + 8-bit Blue.
+    RGB8 = ctru_sys::GPU_RB_RGB8,
+    /// 5-bit Red + 5-bit Green + 5-bit Blue + 1-bit Alpha.
+    RGBA5551 = ctru_sys::GPU_RB_RGBA5551,
+    /// 5-bit Red + 6-bit Green + 5-bit Blue.
+    RGB565 = ctru_sys::GPU_RB_RGB565,
+    /// 4-bit Red + 4-bit Green + 4-bit Blue + 4-bit Alpha.
+    RGBA4 = ctru_sys::GPU_RB_RGBA4,
+}
+
+/// The depth buffer format to use when rendering.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+#[doc(alias = "GPU_DEPTHBUF")]
+#[doc(alias = "C3D_DEPTHTYPE")]
+pub enum DepthFormat {
+    /// 16-bit depth.
+    Depth16 = ctru_sys::GPU_RB_DEPTH16,
+    /// 24-bit depth.
+    Depth24 = ctru_sys::GPU_RB_DEPTH24,
+    /// 24-bit depth + 8-bit Stencil.
+    Depth24Stencil8 = ctru_sys::GPU_RB_DEPTH24_STENCIL8,
+}
 
 /// A render target for `citro3d`. Frame data will be written to this target
 /// to be rendered on the GPU and displayed on the screen.
@@ -27,12 +80,193 @@ pub struct Target<'screen> {
     _queue: Rc<RenderQueue>,
 }
 
-impl Drop for Target<'_> {
-    #[doc(alias = "C3D_RenderTargetDelete")]
-    fn drop(&mut self) {
-        unsafe {
-            C3D_RenderTargetDelete(self.raw);
+#[non_exhaustive]
+#[must_use]
+pub struct RenderPass<'pass> {
+    texenvs: [OnceCell<TexEnv>; texenv::TEXENV_COUNT],
+    _phantom: PhantomData<&'pass mut Instance>,
+}
+
+impl<'pass> RenderPass<'pass> {
+    pub(crate) fn new(_istance: &'pass mut Instance) -> Self {
+        Self {
+            texenvs: [
+                // thank goodness there's only six of them!
+                OnceCell::new(),
+                OnceCell::new(),
+                OnceCell::new(),
+                OnceCell::new(),
+                OnceCell::new(),
+                OnceCell::new(),
+            ],
+            _phantom: PhantomData,
         }
+    }
+
+    /// Select the given render target for drawing the frame. This must be called
+    /// as pare of a render call (i.e. within the call to
+    /// [`render_frame_with`](Self::render_frame_with)).
+    ///
+    /// # Errors
+    ///
+    /// Fails if the given target cannot be used for drawing, or called outside
+    /// the context of a frame render.
+    #[doc(alias = "C3D_FrameDrawOn")]
+    pub fn select_render_target(&mut self, target: &'pass Target<'_>) -> Result<()> {
+        let _ = self;
+        if unsafe { citro3d_sys::C3D_FrameDrawOn(target.as_raw()) } {
+            Ok(())
+        } else {
+            Err(Error::InvalidRenderTarget)
+        }
+    }
+
+    /// Get the buffer info being used, if it exists. Note that the resulting
+    /// [`buffer::Info`] is copied from the one currently in use.
+    #[doc(alias = "C3D_GetBufInfo")]
+    pub fn buffer_info(&self) -> Option<buffer::Info> {
+        let raw = unsafe { citro3d_sys::C3D_GetBufInfo() };
+        buffer::Info::copy_from(raw)
+    }
+
+    /// Set the buffer info to use for any following draw calls.
+    #[doc(alias = "C3D_SetBufInfo")]
+    pub fn set_buffer_info(&mut self, buffer_info: &buffer::Info) {
+        let raw: *const _ = &buffer_info.0;
+        // LIFETIME SAFETY: C3D_SetBufInfo actually copies the pointee instead of mutating it.
+        unsafe { citro3d_sys::C3D_SetBufInfo(raw.cast_mut()) };
+    }
+
+    /// Get the attribute info being used, if it exists. Note that the resulting
+    /// [`attrib::Info`] is copied from the one currently in use.
+    #[doc(alias = "C3D_GetAttrInfo")]
+    pub fn attr_info(&self) -> Option<attrib::Info> {
+        let raw = unsafe { citro3d_sys::C3D_GetAttrInfo() };
+        attrib::Info::copy_from(raw)
+    }
+
+    /// Set the attribute info to use for any following draw calls.
+    #[doc(alias = "C3D_SetAttrInfo")]
+    pub fn set_attr_info(&mut self, attr_info: &attrib::Info) {
+        let raw: *const _ = &attr_info.0;
+        // LIFETIME SAFETY: C3D_SetAttrInfo actually copies the pointee instead of mutating it.
+        unsafe { citro3d_sys::C3D_SetAttrInfo(raw.cast_mut()) };
+    }
+
+    /// Render primitives from the current vertex array buffer.
+    #[doc(alias = "C3D_DrawArrays")]
+    pub fn draw_arrays(&mut self, primitive: buffer::Primitive, vbo_data: buffer::Slice<'pass>) {
+        self.set_buffer_info(vbo_data.info());
+
+        // TODO: should we also require the attrib info directly here?
+        unsafe {
+            citro3d_sys::C3D_DrawArrays(
+                primitive as ctru_sys::GPU_Primitive_t,
+                vbo_data.index(),
+                vbo_data.len(),
+            );
+        }
+    }
+
+    /// Indexed drawing. Draws the vertices in `buf` indexed by `indices`.
+    #[doc(alias = "C3D_DrawElements")]
+    pub fn draw_elements<I: Index>(
+        &mut self,
+        primitive: buffer::Primitive,
+        vbo_data: buffer::Slice<'pass>,
+        indices: &Indices<'pass, I>,
+    ) {
+        self.set_buffer_info(vbo_data.info());
+
+        let indices = &indices.buffer;
+        let elements = indices.as_ptr().cast();
+
+        unsafe {
+            citro3d_sys::C3D_DrawElements(
+                primitive as ctru_sys::GPU_Primitive_t,
+                indices.len().try_into().unwrap(),
+                // flag bit for short or byte
+                I::TYPE,
+                elements,
+            );
+        }
+    }
+
+    /// Use the given [`shader::Program`] for subsequent draw calls.
+    pub fn bind_program(&mut self, program: &'pass shader::Program) {
+        // SAFETY: AFAICT C3D_BindProgram just copies pointers from the given program,
+        // instead of mutating the pointee in any way that would cause UB
+        unsafe {
+            citro3d_sys::C3D_BindProgram(program.as_raw().cast_mut());
+        }
+    }
+
+    /// Binds a [`LightEnv`] for the following draw calls.
+    pub fn bind_light_env(&mut self, env: Option<&'pass mut Pin<Box<LightEnv>>>) {
+        unsafe {
+            citro3d_sys::C3D_LightEnvBind(
+                env.map_or(std::ptr::null_mut(), |env| env.as_mut().as_raw_mut()),
+            );
+        }
+    }
+
+    /// Bind a uniform to the given `index` in the vertex shader for the next draw call.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use citro3d::uniform;
+    /// # use citro3d::math::Matrix4;
+    /// #
+    /// # let mut instance = citro3d::Instance::new().unwrap();
+    /// let idx = uniform::Index::from(0);
+    /// let mtx = Matrix4::identity();
+    /// instance.bind_vertex_uniform(idx, &mtx);
+    /// ```
+    pub fn bind_vertex_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
+        // LIFETIME SAFETY: Uniform data is copied into global buffers.
+        uniform.into().bind(self, shader::Type::Vertex, index);
+    }
+
+    /// Bind a uniform to the given `index` in the geometry shader for the next draw call.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # use citro3d::uniform;
+    /// # use citro3d::math::Matrix4;
+    /// #
+    /// # let mut instance = citro3d::Instance::new().unwrap();
+    /// let idx = uniform::Index::from(0);
+    /// let mtx = Matrix4::identity();
+    /// instance.bind_geometry_uniform(idx, &mtx);
+    /// ```
+    pub fn bind_geometry_uniform(&mut self, index: uniform::Index, uniform: impl Into<Uniform>) {
+        // LIFETIME SAFETY: Uniform data is copied into global buffers.
+        uniform.into().bind(self, shader::Type::Geometry, index);
+    }
+
+    /// Retrieve the [`TexEnv`] for the given stage, initializing it first if necessary.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use citro3d::texenv;
+    /// # let _runner = test_runner::GdbRunner::default();
+    /// # let mut instance = citro3d::Instance::new().unwrap();
+    /// let stage0 = texenv::Stage::new(0).unwrap();
+    /// let texenv0 = instance.texenv(stage0);
+    /// ```
+    #[doc(alias = "C3D_GetTexEnv")]
+    #[doc(alias = "C3D_TexEnvInit")]
+    pub fn texenv(&mut self, stage: texenv::Stage) -> &mut texenv::TexEnv {
+        let texenv = &mut self.texenvs[stage.0];
+        texenv.get_or_init(|| TexEnv::new(stage));
+        // We have to do this weird unwrap to get a mutable reference,
+        // since there is no `get_mut_or_init` or equivalent
+        texenv.get_mut().unwrap()
     }
 }
 
@@ -98,34 +332,13 @@ impl<'screen> Target<'screen> {
     }
 }
 
-bitflags::bitflags! {
-    /// Indicate whether color, depth buffer, or both values should be cleared.
-    #[doc(alias = "C3D_ClearBits")]
-    pub struct ClearFlags: u8 {
-        /// Clear the color of the render target.
-        const COLOR = citro3d_sys::C3D_CLEAR_COLOR;
-        /// Clear the depth buffer value of the render target.
-        const DEPTH = citro3d_sys::C3D_CLEAR_DEPTH;
-        /// Clear both color and depth buffer values of the render target.
-        const ALL = citro3d_sys::C3D_CLEAR_ALL;
+impl Drop for Target<'_> {
+    #[doc(alias = "C3D_RenderTargetDelete")]
+    fn drop(&mut self) {
+        unsafe {
+            C3D_RenderTargetDelete(self.raw);
+        }
     }
-}
-
-/// The color format to use when rendering on the GPU.
-#[repr(u8)]
-#[derive(Clone, Copy, Debug)]
-#[doc(alias = "GPU_COLORBUF")]
-pub enum ColorFormat {
-    /// 8-bit Red + 8-bit Green + 8-bit Blue + 8-bit Alpha.
-    RGBA8 = ctru_sys::GPU_RB_RGBA8,
-    /// 8-bit Red + 8-bit Green + 8-bit Blue.
-    RGB8 = ctru_sys::GPU_RB_RGB8,
-    /// 5-bit Red + 5-bit Green + 5-bit Blue + 1-bit Alpha.
-    RGBA5551 = ctru_sys::GPU_RB_RGBA5551,
-    /// 5-bit Red + 6-bit Green + 5-bit Blue.
-    RGB565 = ctru_sys::GPU_RB_RGB565,
-    /// 4-bit Red + 4-bit Green + 4-bit Blue + 4-bit Alpha.
-    RGBA4 = ctru_sys::GPU_RB_RGBA4,
 }
 
 impl From<FramebufferFormat> for ColorFormat {
@@ -139,20 +352,6 @@ impl From<FramebufferFormat> for ColorFormat {
             FramebufferFormat::Bgr8 => Self::RGB8,
         }
     }
-}
-
-/// The depth buffer format to use when rendering.
-#[repr(u8)]
-#[derive(Clone, Copy, Debug)]
-#[doc(alias = "GPU_DEPTHBUF")]
-#[doc(alias = "C3D_DEPTHTYPE")]
-pub enum DepthFormat {
-    /// 16-bit depth.
-    Depth16 = ctru_sys::GPU_RB_DEPTH16,
-    /// 24-bit depth.
-    Depth24 = ctru_sys::GPU_RB_DEPTH24,
-    /// 24-bit depth + 8-bit Stencil.
-    Depth24Stencil8 = ctru_sys::GPU_RB_DEPTH24_STENCIL8,
 }
 
 impl DepthFormat {

--- a/citro3d/src/uniform.rs
+++ b/citro3d/src/uniform.rs
@@ -4,7 +4,7 @@
 use std::ops::Range;
 
 use crate::math::{FVec4, IVec, Matrix4};
-use crate::{Instance, shader};
+use crate::{RenderPass, shader};
 
 /// The index of a uniform within a [`shader::Program`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -73,9 +73,9 @@ impl Uniform {
 
     /// Bind a uniform
     ///
-    /// Note: `_instance` is here to ensure unique access to the global uniform buffers
+    /// Note: `_pass` is here to ensure unique access to the global uniform buffers
     /// otherwise we could race and/or violate aliasing
-    pub(crate) fn bind(self, _instance: &mut Instance, ty: shader::Type, index: Index) {
+    pub(crate) fn bind(self, _pass: &mut RenderPass, ty: shader::Type, index: Index) {
         assert!(
             self.index_range().contains(&index),
             "tried to bind uniform to an invalid index (index: {:?}, valid range: {:?})",
@@ -89,6 +89,7 @@ impl Uniform {
             self.len(),
             self.index_range().end
         );
+
         let set_fvs = |fs: &[FVec4]| {
             for (off, f) in fs.iter().enumerate() {
                 unsafe {
@@ -103,6 +104,7 @@ impl Uniform {
                 }
             }
         };
+
         match self {
             Self::Bool(b) => unsafe {
                 citro3d_sys::C3D_BoolUnifSet(ty.into(), index.into(), b);


### PR DESCRIPTION
Fixes #37 (and possibly #36, but textures are not yet implemented)

This PR changes the rendering paradigm to use a `RenderPass` struct. This struct is effectively a *marker* of the frame's lifetime, and handles all draw and binding calls (instead of `Instance`). It does *not* hold references or copies of the render data.

The struct's calls take references of `'frame` lifetime, so that it is statically checked that no items used in the rendering can be  dropped before `C3D_FrameEnd`.

# Example with shader programs
If the program is instantiated outside the `render_frame_with` function (and thus, due to borrowing, lives for longer), the rendering is done as intended.

Instead, putting the shader program initialization within the render call, would cause this error:
```
error[E0597]: `program` does not live long enough
   --> citro3d/examples/triangle.rs:103:31
    |
100 |         instance.render_frame_with(|mut pass| {
    |                                     -------- has type `RenderPass<'1>`
101 |             let program = shader::Program::new(vertex_shader).unwrap();
    |                 ------- binding `program` declared here
102 |             let projection_uniform_idx = program.get_uniform("projection").unwrap();
103 |             pass.bind_program(&program);
    |             ------------------^^^^^^^^-
    |             |                 |
    |             |                 borrowed value does not live long enough
    |             argument requires that `program` is borrowed for `'1`
...
144 |         });
    |         - `program` dropped here while still borrowed
 ```

Or, adding a `drop()` call after calling `bind_program()` would cause this error:

```
error[E0505]: cannot move out of `program` because it is borrowed
   --> citro3d/examples/triangle.rs:105:18
    |
 87 |     let program = shader::Program::new(vertex_shader).unwrap();
    |         ------- binding `program` declared here
...
103 |         instance.render_frame_with(|mut pass| {
    |                                     -------- has type `RenderPass<'1>`
104 |             pass.bind_program(&program);
    |             ---------------------------
    |             |                 |
    |             |                 borrow of `program` occurs here
    |             argument requires that `program` is borrowed for `'1`
105 |             drop(program);
    |                  ^^^^^^^ move out of `program` occurs here
```

# Pros and cons
- Statically checked lifetimes at compilation time
- No copying of data within redundant internal representation (only uses the raw C3D context).
- Data that gets copied within the C3D context (such as uniform buffers) can be handled without the special lifetime requirements.

- I weren't able to encode the lifetime requirement into the `render_to` closure we previously used in our examples, so that became a standalone function (with some quite verbose arguments...).

# Draft

Left to be implemented before un-drafting the PR:
- [ ] `Drop` implementation for `RenderPass` to clear "global context", such as `LightEnvs` and bound shader programs.
- [ ] Examples other than `triangle`