### PR TITLE
Feat: Owned buffers and arbitrary buffer/attribute layouts

### DIFF
--- a/citro3d/examples/cube.rs
+++ b/citro3d/examples/cube.rs
@@ -126,7 +126,7 @@ fn main() {
     let attr_info = build_attrib_info();
 
     let mut buf_info = buffer::Info::new();
-    buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
     let camera_transform = Matrix4::looking_at(
@@ -203,15 +203,12 @@ fn build_attrib_info() -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
-    let reg0 = attrib::Register::new(0).unwrap();
-    let reg1 = attrib::Register::new(1).unwrap();
-
     attr_info
-        .add_loader(reg0, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V0, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info
-        .add_loader(reg1, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V1, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -408,23 +408,19 @@ fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) ->
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
-    let reg0 = attrib::Register::new(0).unwrap();
-    let reg1 = attrib::Register::new(1).unwrap();
-    let reg2 = attrib::Register::new(2).unwrap();
-
     attr_info
-        .add_loader(reg0, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V0, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info
-        .add_loader(reg1, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V1, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info
-        .add_loader(reg2, attrib::Format::Float, 2)
+        .add_loader(attrib::Register::V2, attrib::Format::Float, 2)
         .unwrap();
 
-    buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
 }

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -404,7 +404,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 

--- a/citro3d/examples/multiple-buffers.rs
+++ b/citro3d/examples/multiple-buffers.rs
@@ -142,8 +142,8 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(
-    buf_info: &'a mut buffer::Info,
+fn prepare_vbos(
+    buf_info: &mut buffer::Info,
     positions: buffer::Buffer,
     cols: buffer::Buffer,
 ) -> attrib::Info {

--- a/citro3d/examples/render-to-texture.rs
+++ b/citro3d/examples/render-to-texture.rs
@@ -196,18 +196,15 @@ fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) ->
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
-    let reg0 = attrib::Register::new(0).unwrap();
-    let reg1 = attrib::Register::new(1).unwrap();
-
     attr_info
-        .add_loader(reg0, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V0, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info
-        .add_loader(reg1, attrib::Format::Float, 2)
+        .add_loader(attrib::Register::V1, attrib::Format::Float, 2)
         .unwrap();
 
-    buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
 }

--- a/citro3d/examples/render-to-texture.rs
+++ b/citro3d/examples/render-to-texture.rs
@@ -192,7 +192,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 

--- a/citro3d/examples/skybox.rs
+++ b/citro3d/examples/skybox.rs
@@ -231,7 +231,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 

--- a/citro3d/examples/skybox.rs
+++ b/citro3d/examples/skybox.rs
@@ -235,13 +235,11 @@ fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) ->
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
-    let reg0 = attrib::Register::new(0).unwrap();
-
     attr_info
-        .add_loader(reg0, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V0, attrib::Format::Float, 3)
         .unwrap();
 
-    buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
 }

--- a/citro3d/examples/skybox.rs
+++ b/citro3d/examples/skybox.rs
@@ -135,11 +135,9 @@ fn main() {
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
     let model_view_uniform_idx = program.get_uniform("modelView").unwrap();
 
-    let mut vbo_data = Vec::with_capacity_in(VERTICES.len(), ctru::linear::LinearAllocator);
-    vbo_data.extend_from_slice(VERTICES);
-
+    let vbo_data = buffer::Buffer::new(VERTICES);
     let mut buf_info = buffer::Info::new();
-    let (attr_info, vbo_data) = prepare_vbos(&mut buf_info, &vbo_data);
+    let attr_info = prepare_vbos(&mut buf_info, vbo_data);
 
     let tex = create_texture();
 
@@ -207,7 +205,9 @@ fn main() {
                     .expect("failed to set render target");
                 frame.bind_vertex_uniform(projection_uniform_idx, projection);
                 frame.bind_vertex_uniform(model_view_uniform_idx, model_view);
-                frame.draw_arrays(buffer::Primitive::Triangles, vbo_data);
+                frame
+                    .draw_arrays(buffer::Primitive::Triangles, &buf_info, None)
+                    .unwrap();
             });
 
             frame.bind_program(&program);
@@ -231,10 +231,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(
-    buf_info: &'a mut buffer::Info,
-    vbo_data: &'a [Vertex],
-) -> (attrib::Info, buffer::Slice<'a>) {
+fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
@@ -244,9 +241,9 @@ fn prepare_vbos<'a>(
         .add_loader(reg0, attrib::Format::Float, 3)
         .unwrap();
 
-    let buf_idx = buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, &attr_info).unwrap();
 
-    (attr_info, buf_idx)
+    attr_info
 }
 
 struct Projections {

--- a/citro3d/examples/textured.rs
+++ b/citro3d/examples/textured.rs
@@ -110,11 +110,10 @@ fn main() {
     let program = shader::Program::new(vertex_shader).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
 
-    let mut vbo_data = Vec::with_capacity_in(VERTICES.len(), ctru::linear::LinearAllocator);
-    vbo_data.extend_from_slice(VERTICES);
+    let vbo_data = buffer::Buffer::new(VERTICES);
 
     let mut buf_info = buffer::Info::new();
-    let (attr_info, vbo_data) = prepare_vbos(&mut buf_info, &vbo_data);
+    let attr_info = prepare_vbos(&mut buf_info, vbo_data);
 
     let tex = create_texture();
 
@@ -149,7 +148,9 @@ fn main() {
 
                 // Binding of the kitten texture
                 frame.bind_texture(texture::Index::Texture0, &tex);
-                frame.draw_arrays(buffer::Primitive::Triangles, vbo_data);
+                frame
+                    .draw_arrays(buffer::Primitive::Triangles, &buf_info, None)
+                    .unwrap();
             });
 
             frame.bind_program(&program);
@@ -169,10 +170,8 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(
-    buf_info: &'a mut buffer::Info,
-    vbo_data: &'a [Vertex],
-) -> (attrib::Info, buffer::Slice<'a>) {
+fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+    // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
     let reg0 = attrib::Register::new(0).unwrap();
@@ -186,9 +185,9 @@ fn prepare_vbos<'a>(
         .add_loader(reg1, attrib::Format::Float, 2)
         .unwrap();
 
-    let buf_idx = buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, &attr_info).unwrap();
 
-    (attr_info, buf_idx)
+    attr_info
 }
 
 struct Projections {

--- a/citro3d/examples/textured.rs
+++ b/citro3d/examples/textured.rs
@@ -174,18 +174,15 @@ fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) ->
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 
-    let reg0 = attrib::Register::new(0).unwrap();
-    let reg1 = attrib::Register::new(1).unwrap();
-
     attr_info
-        .add_loader(reg0, attrib::Format::Float, 3)
+        .add_loader(attrib::Register::V0, attrib::Format::Float, 3)
         .unwrap();
 
     attr_info
-        .add_loader(reg1, attrib::Format::Float, 2)
+        .add_loader(attrib::Register::V1, attrib::Format::Float, 2)
         .unwrap();
 
-    buf_info.add(vbo_data, &attr_info).unwrap();
+    buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
 }

--- a/citro3d/examples/textured.rs
+++ b/citro3d/examples/textured.rs
@@ -170,7 +170,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 

--- a/citro3d/examples/triangle.rs
+++ b/citro3d/examples/triangle.rs
@@ -151,7 +151,7 @@ fn main() {
     }
 }
 
-fn prepare_vbos<'a>(buf_info: &'a mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
+fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib::Info {
     // Configure attributes for use with the vertex shader
     let mut attr_info = attrib::Info::new();
 

--- a/citro3d/src/attrib.rs
+++ b/citro3d/src/attrib.rs
@@ -7,33 +7,107 @@
 
 use std::mem::MaybeUninit;
 
+/// A shader input register, usually corresponding to a single vertex attribute
+/// (e.g. position or color). These are called `v0`, `v1`, ... `v15` in the
+/// [picasso](https://github.com/devkitPro/picasso/blob/master/Manual.md)
+/// shader language.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum Register {
+    V0 = 0,
+    V1 = 1,
+    V2 = 2,
+    V3 = 3,
+    V4 = 4,
+    V5 = 5,
+    V6 = 6,
+    V7 = 7,
+    V8 = 8,
+    V9 = 9,
+    V10 = 10,
+    V11 = 11,
+    V12 = 12,
+    V13 = 13,
+    V14 = 14,
+    V15 = 15,
+}
+
+/// The permutation of a buffer containing vertex attribute data.
+/// The Permutation maps the layout of an input buffer's fields to the
+/// input registers used in the picasso shader.
+#[derive(Debug, Copy, Clone)]
+pub struct Permutation {
+    pub(crate) permutation: u64,
+    pub(crate) attrib_count: u8,
+}
+
+impl Permutation {
+    /// Construct the permutation for a buffer whos fields (in order) correspond to the
+    /// provided list of input registers (as used in the picasso shader).
+    ///
+    /// # Example
+    /// ## Picasso
+    /// ```
+    /// ; Inputs (defined as aliases for convenience)
+    /// .alias inpos         v0 ; fvec3
+    /// .alias innorm        v1 ; fvec3
+    /// .alias intex         v2 ; fvec2
+    /// ```
+    ///
+    /// ## Rust
+    ///
+    /// ```
+    /// struct Vertex {
+    ///     pos: [f32; 3],
+    ///     tex: [f32; 2],
+    /// }
+    ///
+    /// impl Vertex {
+    ///     pub fn permutation() -> Permutation {
+    ///         Permutation::from_layout(&[Register::V0, Register::V2]).unwrap()
+    ///     }
+    /// }
+    ///
+    /// struct Normal {
+    ///     norm: [f32; 3],
+    /// }
+    ///
+    /// impl Normal {
+    ///     pub fn permutation() -> Permutation {
+    ///         Permutation::from_layout(&[Register::V1]).unwrap()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// * If more than 16 attribute registers are provided (i.e. `layout.len() > 16`)
+    pub fn from_layout(layout: &[Register]) -> Result<Self, crate::Error> {
+        if layout.len() > 16 {
+            return Err(crate::Error::IndexOutOfBounds {
+                idx: (layout.len() - 1) as i32,
+                len: 16,
+            });
+        }
+
+        let mut perm: u64 = 0;
+
+        for (i, l) in layout.into_iter().enumerate() {
+            perm |= (*l as u64) << (i * 4);
+        }
+
+        Ok(Self {
+            permutation: perm,
+            attrib_count: layout.len() as u8,
+        })
+    }
+}
+
 /// Vertex attribute info. This struct describes how vertex buffers are
 /// layed out and used (i.e. the shape of the vertex data).
 #[derive(Debug)]
 #[doc(alias = "C3D_AttrInfo")]
 pub struct Info(pub(crate) citro3d_sys::C3D_AttrInfo);
-
-/// A shader input register, usually corresponding to a single vertex attribute
-/// (e.g. position or color). These are called `v0`, `v1`, ... `v15` in the
-/// [picasso](https://github.com/devkitPro/picasso/blob/master/Manual.md)
-/// shader language.
-#[derive(Debug, Clone, Copy)]
-pub struct Register(libc::c_int);
-
-impl Register {
-    /// Get a register corresponding to the given index.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for `n >= 16`.
-    pub fn new(n: u16) -> crate::Result<Self> {
-        if n < 16 {
-            Ok(Self(n.into()))
-        } else {
-            Err(crate::Error::TooManyAttributes)
-        }
-    }
-}
 
 /// An attribute index. This is the attribute's actual index in the input buffer,
 /// and may correspond to any [`Register`] (or multiple) as input in the shader
@@ -124,7 +198,7 @@ impl Info {
         // SAFETY: the &mut self.0 reference is only used to access fields in
         // the attribute info, not stored somewhere for later use
         let ret = unsafe {
-            citro3d_sys::AttrInfo_AddLoader(&mut self.0, register.0, format.into(), count.into())
+            citro3d_sys::AttrInfo_AddLoader(&mut self.0, register as _, format.into(), count.into())
         };
 
         let Ok(idx) = ret.try_into() else {
@@ -134,8 +208,15 @@ impl Info {
         Ok(Index(idx))
     }
 
-    pub(crate) fn permutation(&self) -> u64 {
-        self.0.permutation
+    /// Get the [`Permutation`] for a buffer with elements containing all the fields
+    /// added to this `Info`. If the buffer elements do not contain all the fields
+    /// or contain them in a different order than they were added to this `Info`,
+    /// construct the [`Permutation`] yourself using [`Permutation::from_layout`].
+    pub fn permutation(&self) -> Permutation {
+        Permutation {
+            permutation: self.0.permutation,
+            attrib_count: self.attr_count() as u8,
+        }
     }
 
     /// Get the number of registered attributes.

--- a/citro3d/src/attrib.rs
+++ b/citro3d/src/attrib.rs
@@ -92,7 +92,7 @@ impl Permutation {
 
         let mut perm: u64 = 0;
 
-        for (i, l) in layout.into_iter().enumerate() {
+        for (i, l) in layout.iter().enumerate() {
             perm |= (*l as u64) << (i * 4);
         }
 

--- a/citro3d/src/buffer.rs
+++ b/citro3d/src/buffer.rs
@@ -3,104 +3,194 @@
 //! See the [`attrib`] module for details on how to describe the shape and type
 //! of the VBO data.
 
+use std::any::type_name;
+use std::ffi::c_void;
 use std::mem::MaybeUninit;
+use std::rc::Rc;
 
 use ctru::linear::LinearAllocator;
 
 use crate::Error;
 use crate::attrib;
 
-/// Vertex buffer info. This struct is used to describe the shape of the buffer
-/// data to be sent to the GPU for rendering.
-#[derive(Debug)]
-#[doc(alias = "C3D_BufInfo")]
-pub struct Info(pub(crate) citro3d_sys::C3D_BufInfo);
-
-/// A slice of buffer data. This borrows the buffer data and can be thought of
-/// as similar to `&[T]` obtained by slicing a `Vec<T>`.
-#[derive(Debug, Clone, Copy)]
-pub struct Slice<'buf> {
-    index: libc::c_int,
-    size: libc::c_int,
-    buf_info: &'buf Info,
-    // TODO: should we encapsulate the primitive here too, and require it when the
-    // slice is registered? Could there ever be a use case to draw different primitives
-    // using the same backing data???
+/// A buffer allocated in Linear memory.
+pub trait BufferData: 'static {
+    /// A pointer to the underlying data
+    fn buf_ptr(&self) -> *mut c_void;
+    /// The size (in bytes) of each element in the buffer
+    fn stride(&self) -> usize;
+    /// How many elements are in the buffer
+    fn buf_len(&self) -> usize;
 }
 
-impl Slice<'_> {
-    /// Get the index into the buffer for this slice.
-    pub fn index(&self) -> libc::c_int {
-        self.index
+impl<T: Sized + 'static> BufferData for Vec<T, LinearAllocator> {
+    fn buf_ptr(&self) -> *mut c_void {
+        self.as_ptr() as _
     }
 
-    /// Get the length of the slice.
-    #[must_use]
-    pub fn len(&self) -> libc::c_int {
-        self.size
+    fn stride(&self) -> usize {
+        std::mem::size_of::<T>()
     }
 
-    /// Return whether or not the slice has any elements.
-    pub fn is_empty(&self) -> bool {
-        self.len() <= 0
+    fn buf_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: Sized + 'static> BufferData for Box<[T], LinearAllocator> {
+    fn buf_ptr(&self) -> *mut c_void {
+        self.as_ref() as *const _ as _
     }
 
-    /// Get the buffer info this slice is associated with.
-    pub fn info(&self) -> &Info {
-        self.buf_info
+    fn stride(&self) -> usize {
+        std::mem::size_of::<T>()
     }
 
-    /// Get an index buffer for this slice using the given indices.
+    fn buf_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: Sized + 'static> BufferData for Rc<[T], LinearAllocator> {
+    fn buf_ptr(&self) -> *mut c_void {
+        self.as_ref() as *const _ as _
+    }
+
+    fn stride(&self) -> usize {
+        std::mem::size_of::<T>()
+    }
+
+    fn buf_len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// A handle to a VBO buffer in linear memory, to be used with [`Info`].
+/// This handle is reference counted so can be cheaply cloned and used
+/// with mutliple [`Info`] instances without duplicating memory.
+#[derive(Clone)]
+pub struct Buffer {
+    _data: Rc<dyn BufferData>,
+
+    // These fields could just be dynamically fetched since the buffer
+    // is dyn BufferVec, or we can spend 12 extra bytes per buffer to
+    // avoid some indirection each draw call.
+    data_ptr: *const c_void,
+    stride: isize,
+    len: usize,
+}
+
+impl Buffer {
+    /// Allocate a new `Buffer` in Linear memory and copy `data` into it.
+    /// Each element of `data` should correspond to data for a single vertex.
+    ///
+    /// If you already have an owned [`Vec`] in Linear memory then
+    /// [`Buffer::new_in_linear`] should be preferred to take ownership
+    /// of that allocation instead of reallocating and copying.
+    pub fn new<T: Sized + Copy + 'static>(data: &[T]) -> Buffer {
+        let mut linear_data = Vec::with_capacity_in(data.len(), LinearAllocator);
+        linear_data.extend_from_slice(data);
+
+        Buffer {
+            data_ptr: linear_data.as_ptr() as _,
+            len: linear_data.len(),
+            stride: linear_data
+                .stride()
+                .try_into()
+                .map_err(|_| format!("{} is too large to be used in a buffer.", type_name::<T>()))
+                .unwrap(),
+            _data: Rc::new(linear_data),
+        }
+    }
+
+    /// Allocate a new `Buffer` in Linear memory and copy `data` into it.
+    /// The `stride` should correspond to the number of bytes in data
+    /// per single vertex.
+    ///
+    /// If you already have an owned [`Vec`] in Linear memory then
+    /// [`Buffer::new_in_linear_with_stride`] should be preferred to take ownership
+    /// of that allocation instead of reallocating and copying.
     ///
     /// # Errors
-    ///
-    /// Returns an error if:
-    /// - any of the given indices are out of bounds.
-    /// - the given slice is too long for its length to fit in a `libc::c_int`.
-    pub fn index_buffer<I>(&self, indices: &[I]) -> Result<Indices<'_, I>, Error>
-    where
-        I: Index + Copy + Into<libc::c_int>,
-    {
-        if libc::c_int::try_from(indices.len()).is_err() {
-            return Err(Error::InvalidSize);
+    /// * If the length of `data` is not a mutliple of `stride`
+    pub fn new_with_stride(data: &[u8], stride: usize) -> Result<Buffer, ()> {
+        if data.len() % stride != 0 {
+            return Err(());
         }
 
-        for &idx in indices {
-            let idx = idx.into();
-            let len = self.len();
-            if idx >= len {
-                return Err(Error::IndexOutOfBounds { idx, len });
-            }
-        }
+        let mut linear_data = Vec::with_capacity_in(data.len(), LinearAllocator);
+        linear_data.extend_from_slice(data);
 
-        Ok(unsafe { self.index_buffer_unchecked(indices) })
+        Ok(Buffer {
+            data_ptr: linear_data.as_ptr() as _,
+            len: linear_data.len() / stride,
+            stride: stride as isize,
+            _data: Rc::new(linear_data),
+        })
     }
 
-    /// Get an index buffer for this slice using the given indices without
-    /// bounds checking.
-    ///
-    /// # Safety
-    ///
-    /// If any indices are outside this buffer it can cause an invalid access by the GPU
-    /// (this crashes citra).
-    pub unsafe fn index_buffer_unchecked<I: Index + Clone>(&self, indices: &[I]) -> Indices<'_, I> {
-        let mut buffer = Vec::with_capacity_in(indices.len(), LinearAllocator);
-        buffer.extend_from_slice(indices);
-        Indices {
-            buffer,
-            _slice: *self,
+    /// Convert an existing buffer allocated in Linear memory to a `Buffer` to be used
+    /// with [`buffer::Info`]. Each element in `data` should correspond with data for
+    /// a single vertex.
+    pub fn new_in_linear<B: BufferData>(data: B) -> Buffer {
+        Buffer {
+            data_ptr: data.buf_ptr() as _,
+            stride: data
+                .stride()
+                .try_into()
+                .map_err(|_| format!("{}'s buffer elements are too large.", type_name::<B>()))
+                .unwrap(),
+            len: data.buf_len(),
+            _data: Rc::new(data),
         }
+    }
+
+    /// Convert an existing buffer of unstructured data allocated in Linear memory
+    /// e.g. `Vec<u8, LinearAllocator>` to a `Buffer` to be used with [`buffer::Info`].
+    /// Each element in `data` should correspond with data for a single vertex.
+    ///
+    /// # Errors
+    /// * If the length of `data` is not a mutliple of `stride`
+    pub fn new_in_linear_with_stride(data: impl BufferData, stride: usize) -> Result<Buffer, ()> {
+        if data.buf_len() % stride != 0 {
+            return Err(());
+        }
+
+        Ok(Buffer {
+            data_ptr: data.buf_ptr() as _,
+            stride: stride
+                .try_into()
+                .map_err(|_| format!("{stride} is too large for a buffer element."))
+                .unwrap(),
+            len: data.buf_len() / stride,
+            _data: Rc::new(data),
+        })
+    }
+
+    pub fn as_ptr(&self) -> *const c_void {
+        self.data_ptr
+    }
+
+    pub fn stride(&self) -> isize {
+        self.stride
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
     }
 }
 
-/// An index buffer for indexed drawing. See [`Slice::index_buffer`] to obtain one.
-pub struct Indices<'buf, I> {
-    pub(crate) buffer: Vec<I, LinearAllocator>,
-    _slice: Slice<'buf>,
+/// Vertex buffer info. This struct is used to describe the shape of the buffer
+/// data to be sent to the GPU for rendering.
+#[doc(alias = "C3D_BufInfo")]
+#[derive(Clone)]
+pub struct Info {
+    info: citro3d_sys::C3D_BufInfo,
+    buffers: Vec<Buffer>,
 }
 
 /// A type that can be used as an index for indexed drawing.
-pub trait Index: crate::private::Sealed {
+pub trait Index {
     /// The data type of the index, as used by [`citro3d_sys::C3D_DrawElements`]'s `type_` parameter.
     const TYPE: libc::c_int;
 }
@@ -137,24 +227,25 @@ impl Default for Info {
             citro3d_sys::BufInfo_Init(info.as_mut_ptr());
             info.assume_init()
         };
-        Self(info)
+        Self {
+            info,
+            buffers: Vec::new(),
+        }
     }
 }
 
 impl Info {
+    pub fn as_raw(&self) -> *mut citro3d_sys::C3D_BufInfo {
+        &self.info as *const _ as _
+    }
+
     /// Construct buffer info without any registered data.
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub(crate) fn copy_from(raw: *const citro3d_sys::C3D_BufInfo) -> Option<Self> {
-        if raw.is_null() {
-            None
-        } else {
-            // This is less efficient than returning a pointer or something, but it's
-            // safer since we don't know the lifetime of the pointee
-            Some(Self(unsafe { *raw }))
-        }
+    pub fn len(&self) -> u16 {
+        self.buffers.first().map(|b| b.len() as _).unwrap_or(0)
     }
 
     /// Register vertex buffer object data. The resulting [`Slice`] will have its
@@ -169,25 +260,24 @@ impl Info {
     /// * if `vbo_data` is not allocated with the [`ctru::linear`] allocator
     /// * if the maximum number (12) of VBOs are already registered
     #[doc(alias = "BufInfo_Add")]
-    pub fn add<'this, 'vbo, 'idx, T>(
+    pub fn add<'this, 'idx>(
         &'this mut self,
-        vbo_data: &'vbo [T],
+        vbo_buffer: Buffer,
         attrib_info: &attrib::Info,
-    ) -> crate::Result<Slice<'idx>>
+    ) -> Result<(), Error>
     where
         'this: 'idx,
-        'vbo: 'idx,
     {
-        let stride = std::mem::size_of::<T>().try_into()?;
-
-        // SAFETY: the lifetime of the VBO data is encapsulated in the return value's
-        // 'vbo lifetime, and the pointer to &mut self.0 is used to access values
+        // SAFETY:
+        // * The lifetime of the VBO data is extended by the `Buffer` copy that is
+        // stored in `self.buffers` which reference counts the buffer allocation
+        // * The pointer to &mut self.0 is used to access values
         // in the BufInfo, not copied to be used later.
         let res = unsafe {
             citro3d_sys::BufInfo_Add(
-                &mut self.0,
-                vbo_data.as_ptr().cast(),
-                stride,
+                &mut self.info,
+                vbo_buffer.as_ptr().cast(),
+                vbo_buffer.stride(),
                 attrib_info.attr_count(),
                 attrib_info.permutation(),
             )
@@ -198,11 +288,10 @@ impl Info {
             ..=-3 => Err(crate::Error::System(res)),
             -2 => Err(crate::Error::InvalidMemoryLocation),
             -1 => Err(crate::Error::TooManyBuffers),
-            _ => Ok(Slice {
-                index: res,
-                size: vbo_data.len().try_into()?,
-                buf_info: self,
-            }),
+            _ => {
+                self.buffers.push(vbo_buffer);
+                Ok(())
+            }
         }
     }
 }

--- a/citro3d/src/buffer.rs
+++ b/citro3d/src/buffer.rs
@@ -263,7 +263,7 @@ impl Info {
     pub fn add<'this, 'idx>(
         &'this mut self,
         vbo_buffer: Buffer,
-        attrib_info: &attrib::Info,
+        permutation: attrib::Permutation,
     ) -> Result<(), Error>
     where
         'this: 'idx,
@@ -278,8 +278,8 @@ impl Info {
                 &mut self.info,
                 vbo_buffer.as_ptr().cast(),
                 vbo_buffer.stride(),
-                attrib_info.attr_count(),
-                attrib_info.permutation(),
+                permutation.attrib_count as _,
+                permutation.permutation,
             )
         };
 

--- a/citro3d/src/lib.rs
+++ b/citro3d/src/lib.rs
@@ -43,12 +43,6 @@ pub mod macros {
     pub use citro3d_macros::*;
 }
 
-mod private {
-    pub trait Sealed {}
-    impl Sealed for u8 {}
-    impl Sealed for u16 {}
-}
-
 /// Representation of `citro3d`'s internal render queue. This is something that
 /// lives in the global context, but it keeps references to resources that are
 /// used for rendering, so it's useful for us to have something to represent its

--- a/citro3d/src/render.rs
+++ b/citro3d/src/render.rs
@@ -389,6 +389,7 @@ impl<'instance> Frame<'instance> {
     ///
     /// Panics if no shader program was bound (see [`Frame::bind_program`]).
     #[doc(alias = "C3D_DrawElements")]
+    #[allow(clippy::ptr_arg)] // `&Vec<I, LinearAllocator>` is required to ensure it's allocated in the correct memory space, however clippy insists we use `&[I]`
     pub fn draw_elements<I: Index>(
         &mut self,
         primitive: buffer::Primitive,
@@ -531,7 +532,7 @@ impl<'instance> Frame<'instance> {
         }
     }
 
-    /// Bind the given [`Texture`] to the specified [`texture::Unit`], which should
+    /// Bind the given [`texture::Texture`] to the specified [`texture::Unit`], which should
     /// correspond to a source or destination texture configured in the [`TexEnv`].
     pub fn bind_texture(&mut self, index: texture::Index, texture: &'instance texture::Texture) {
         unsafe { texture.bind(index) };

--- a/citro3d/src/render.rs
+++ b/citro3d/src/render.rs
@@ -1,19 +1,20 @@
 //! This module provides render target types and options for controlling transfer
 //! of data to the GPU, including the format of color and depth data to be rendered.
 
-use std::cell::RefMut;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::{cell::RefMut, ops::Range};
 
 use citro3d_sys::{C3D_DEPTHTYPE, C3D_RenderTargetCreate, C3D_RenderTargetDelete};
+use ctru::linear::LinearAllocator;
 use ctru::services::gfx::Screen;
 use ctru::services::gspgpu::FramebufferFormat;
 use ctru_sys::{GPU_COLORBUF, GPU_DEPTHBUF};
 
 use crate::{
     Error, Instance, RenderQueue, Result, attrib,
-    buffer::{self, Index, Indices},
+    buffer::{self, Index},
     light::LightEnv,
     render, shader,
     texenv::{self, TexEnv},
@@ -285,23 +286,11 @@ impl<'instance> Frame<'instance> {
         }
     }
 
-    /// Get the buffer info being used, if it exists.
-    ///
-    /// # Notes
-    ///
-    /// The resulting [`buffer::Info`] is copied (and not taken) from the one currently in use.
-    #[doc(alias = "C3D_GetBufInfo")]
-    pub fn buffer_info(&self) -> Option<buffer::Info> {
-        let raw = unsafe { citro3d_sys::C3D_GetBufInfo() };
-        buffer::Info::copy_from(raw)
-    }
-
     /// Set the buffer info to use for for the following draw calls.
     #[doc(alias = "C3D_SetBufInfo")]
-    pub fn set_buffer_info(&mut self, buffer_info: &buffer::Info) {
-        let raw: *const _ = &buffer_info.0;
-        // LIFETIME SAFETY: C3D_SetBufInfo actually copies the pointee instead of mutating it.
-        unsafe { citro3d_sys::C3D_SetBufInfo(raw.cast_mut()) };
+    pub fn set_buffer_info(&mut self, buffer_info: &'instance buffer::Info) {
+        // LIFETIME SAFETY: The internal buffers of `buffer_info` must be kept alive
+        unsafe { citro3d_sys::C3D_SetBufInfo(buffer_info.as_raw()) };
     }
 
     /// Get the attribute info being used, if it exists.
@@ -324,19 +313,42 @@ impl<'instance> Frame<'instance> {
     }
 
     /// Render primitives from the current vertex array buffer.
+    /// An optional `range` parameter can be provided to use a contiguous sub-
+    /// array of vertices, if none is provided the entire range will be used.
     ///
     /// # Panics
     ///
-    /// Panics if no shader program was bound (see [`Frame::bind_program`]).
+    /// * If no shader program was bound (see [`Frame::bind_program`]).
+    /// * If there are no buffers registered with this [`buffer::Info`].
     #[doc(alias = "C3D_DrawArrays")]
     pub fn draw_arrays(
         &mut self,
         primitive: buffer::Primitive,
-        vbo_data: buffer::Slice<'instance>,
-    ) {
+        buffers: &'instance buffer::Info,
+        range: Option<Range<u16>>,
+    ) -> Result<()> {
         // TODO: Decide whether it's worth returning an `Error` instead of panicking.
         if !self.is_program_bound {
             panic!("Tried to draw arrays when no shader program is bound");
+        }
+
+        let len = buffers.len();
+
+        let start = range.as_ref().map(|r| r.start).unwrap_or(0);
+        if start >= len {
+            return Err(Error::IndexOutOfBounds {
+                idx: start as _,
+                len: len as _,
+            });
+        }
+
+        // len is verified to be >0 from checking the starting index
+        let end = range.as_ref().map(|r| r.end).unwrap_or(len - 1);
+        if end >= len {
+            return Err(Error::IndexOutOfBounds {
+                idx: end as _,
+                len: len as _,
+            });
         }
 
         // Ensure that any textures being referenced by the texture environment
@@ -357,16 +369,18 @@ impl<'instance> Frame<'instance> {
             }
         }
 
-        self.set_buffer_info(vbo_data.info());
+        self.set_buffer_info(buffers);
 
         // TODO: should we also require the attrib info directly here?
         unsafe {
             citro3d_sys::C3D_DrawArrays(
                 primitive as ctru_sys::GPU_Primitive_t,
-                vbo_data.index(),
-                vbo_data.len(),
+                start as _,
+                (end - start + 1) as _,
             );
         }
+
+        Ok(())
     }
 
     /// Draws the vertices in `buf` indexed by `indices`.
@@ -378,8 +392,8 @@ impl<'instance> Frame<'instance> {
     pub fn draw_elements<I: Index>(
         &mut self,
         primitive: buffer::Primitive,
-        vbo_data: buffer::Slice<'instance>,
-        indices: &Indices<'instance, I>,
+        vbo_data: &'instance buffer::Info,
+        indices: &'instance Vec<I, LinearAllocator>,
     ) {
         if !self.is_program_bound {
             panic!("tried to draw elements when no shader program is bound");
@@ -402,9 +416,8 @@ impl<'instance> Frame<'instance> {
             }
         }
 
-        self.set_buffer_info(vbo_data.info());
+        self.set_buffer_info(vbo_data);
 
-        let indices = &indices.buffer;
         let elements = indices.as_ptr().cast();
 
         unsafe {


### PR DESCRIPTION
~~See https://github.com/rust3ds/citro3d-rs/pull/80 before this pull request, as this is based on the commits from that one. Only the last 2 or so commits in this PR are actually relevant. If anything changes in that PR I'll update this branch to match.~~

This PR reworks how vbo buffers and `BufInfo` is handled so that you can own the buffers. Previously when loading buffers and setting up buf info you would have to borrow the buffer data which made it very difficult  to work with and abstract this stuff out like you might in a game engine without just loading everything in main and keeping it permanently borrowed.

It also reworks the attribute loading a little bit to allow for arbitrary buffer layouts or even multiple buffers for storing the attribute data.

# Changes/features
* Reference counted `Buffer` objects that can be cloned/reused in multiple `buffer::Info` objects and will be kept alive as long as all the `buffer::Info` objects containing a copy are alive
* Removed `Slice`
  * `draw_arrays` can be indexed to draw a sub-set of vertices (range is bounds checked)
  * `draw_elements` takes any index array in linear memory, doesn't have to be instantiated through the buffer/bufInfo (Currently this means it is no longer verifying that all of the indices are valid, which is not ideal, but I believe previously even though there was a check when registering an index array with a buffer, it didn't actually validate that it was the correct index array being used at the time of calling `draw_elements`, so I think this issue already existed.)
* Added `attrib::Permutation` to allow for setting the permutation of a buffer in any way you desire
* Replaced `attrib::Register` with an enum
* Added an example for using multiple buffers for attribute data

# Further questions/concerns
* Index array validation?
  * What actually happens if the GPU indexes out of bounds? Hang? Reads garbage? I haven't tested it
  * If this is something we do, do we need some way to associate an index array with a buffer that it has been validated against? It would be good to maintain the ability to use a single index array with multiple `buffer::Info`  objects.
* Should buffers be validating that they contain >= 1 element?
* Should using multiple buffers in one `buffer::Info` require that they all have the same number of elements?
* How does padding affect the attribute layouts and how is that handled? So far everything I've done has "just worked" but I was wondering about how that could get messed up..
* Currently no validation that the bound `attrib::Info` matches the layouts/attribute data in the bound `buffer::Info` (see https://github.com/rust3ds/citro3d-rs/issues/78 and https://github.com/rust3ds/citro3d-rs/issues/55)

Not all of those questions/concerns necessarily have to be answered here and now, but they may need some consideration at some point.