### PR TITLE
Fix use-after free issues with shader programs

### DIFF
--- a/citro3d/Cargo.toml
+++ b/citro3d/Cargo.toml
@@ -39,3 +39,6 @@ all-features = true
 default-target = "armv6k-nintendo-3ds"
 targs = []
 cargo-args = ["-Z", "build-std"]
+
+[package.metadata.cargo-3ds]
+romfs_dir = "examples/assets/romfs"

--- a/citro3d/examples/assets/gshader_geo.pica
+++ b/citro3d/examples/assets/gshader_geo.pica
@@ -1,0 +1,93 @@
+; Example PICA200 geometry shader
+.gsh point c0
+
+; Uniforms
+.fvec projection[4]
+
+; Constants
+.constf myconst(0.0, 1.0, -1.0, 0.5)
+.alias  zeros myconst.xxxx ; Vector full of zeros
+.alias  ones  myconst.yyyy ; Vector full of ones
+.alias  half  myconst.wwww
+
+; Outputs - this time the type *is* used
+.out outpos position
+.out outclr color
+
+; Inputs: we will receive the following inputs:
+; v0-v1: position/color of the first vertex
+; v2-v3: position/color of the second vertex
+; v4-v5: position/color of the third vertex
+
+.entry gmain
+.proc gmain
+	; Calculate the midpoints of the vertices
+	mov r4, v0
+	add r4, v2,   r4
+	mul r4, half, r4
+	mov r5, v2
+	add r5, v4,   r5
+	mul r5, half, r5
+	mov r6, v4
+	add r6, v0,   r6
+	mul r6, half, r6
+
+	; Emit the first triangle
+	mov r0, v0
+	mov r1, r4
+	mov r2, r6
+	call emit_triangle
+
+	; Emit the second triangle
+	mov r0, r4
+	mov r1, v2
+	mov r2, r5
+	call emit_triangle
+
+	; Emit the third triangle
+	mov r0, r6
+	mov r1, r5
+	mov r2, v4
+	call emit_triangle
+
+	; We're finished
+	end
+.end
+
+.proc emit_triangle
+	; Emit the first vertex
+	setemit 0
+	mov r8, r0
+	mov r9, v1
+	call process_vertex
+	emit
+
+	; Emit the second vertex
+	setemit 1
+	mov r8, r1
+	mov r9, v3
+	call process_vertex
+	emit
+
+	; Emit the third vertex and finish the primitive
+	setemit 2, prim
+	mov r8, r2
+	mov r9, v5
+	call process_vertex
+	emit
+.end
+
+; Subroutine
+; Inputs:
+;   r8: vertex position
+;   r9: vertex color
+.proc process_vertex
+	; outpos = projectionMatrix * r8
+	dp4 outpos.x, projection[0], r8
+	dp4 outpos.y, projection[1], r8
+	dp4 outpos.z, projection[2], r8
+	dp4 outpos.w, projection[3], r8
+
+	; outclr = r9
+	mov outclr, r9
+.end

--- a/citro3d/examples/assets/vshader_geo.pica
+++ b/citro3d/examples/assets/vshader_geo.pica
@@ -1,0 +1,26 @@
+; Example PICA200 vertex shader
+
+; Constants
+.constf myconst(0.0, 1.0, -1.0, -0.5)
+.alias  zeros myconst.xxxx ; Vector full of zeros
+.alias  ones  myconst.yyyy ; Vector full of ones
+
+; Outputs - since we are also using a geoshader the output type isn't really used
+.out outpos position
+.out outclr color
+
+; Inputs (defined as aliases for convenience)
+.alias inpos v0
+.alias inclr v1
+
+.entry vmain
+.proc vmain
+	; Pass through both inputs to the geoshader
+	mov outpos.xyz, inpos
+	mov outpos.w,   ones
+	mov outclr.xyz, inclr
+	mov outclr.w,   ones
+
+	; We're finished
+	end
+.end

--- a/citro3d/examples/cube.rs
+++ b/citro3d/examples/cube.rs
@@ -102,9 +102,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
 
     let mut vbo_data = Vec::with_capacity_in(VERTS.len(), ctru::linear::LinearAllocator);
     for vert in VERTS.iter().enumerate().map(|(i, v)| Vertex {

--- a/citro3d/examples/cube.rs
+++ b/citro3d/examples/cube.rs
@@ -102,8 +102,9 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
 
     let mut vbo_data = Vec::with_capacity_in(VERTS.len(), ctru::linear::LinearAllocator);
     for vert in VERTS.iter().enumerate().map(|(i, v)| Vertex {
@@ -127,7 +128,7 @@ fn main() {
     let mut buf_info = buffer::Info::new();
     buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
     let camera_transform = Matrix4::looking_at(
         FVec3::new(1.8, 1.8, 1.8),
         FVec3::new(0.0, 0.0, 0.0),

--- a/citro3d/examples/dynamic-shader.rs
+++ b/citro3d/examples/dynamic-shader.rs
@@ -2,7 +2,6 @@
 
 #![feature(allocator_api)]
 
-use citro3d::macros::include_shader;
 use citro3d::math::{AspectRatio, ClipPlanes, Matrix4, Projection, StereoDisplacement};
 use citro3d::render::{ClearFlags, Frame, ScreenTarget, Target};
 use citro3d::texenv;
@@ -79,7 +78,6 @@ fn main() {
         .render_target(width, height, bottom_screen, None)
         .expect("failed to create bottom screen render target");
 
-
     let _romfs = ctru::services::romfs::RomFS::new().unwrap();
 
     let shader = {
@@ -87,8 +85,10 @@ fn main() {
         shader::Library::from_bytes(shader_bytes).unwrap()
     };
 
-    let program = shader::Program::new(shader, 0).unwrap();
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let vertex_shader = shader.get(0).unwrap();
+
+    let program = shader::Program::new(vertex_shader).unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
 

--- a/citro3d/examples/dynamic-shader.rs
+++ b/citro3d/examples/dynamic-shader.rs
@@ -1,5 +1,4 @@
-//! This example demonstrates the most basic usage of `citro3d`: rendering a simple
-//! RGB triangle (sometimes called a "Hello triangle") to the 3DS screen.
+// This examples demonstrates loading a shader into memory at runtime
 
 #![feature(allocator_api)]
 
@@ -47,7 +46,6 @@ static VERTICES: &[Vertex] = &[
     },
 ];
 
-static SHADER_BYTES: &[u8] = include_shader!("assets/vshader.pica");
 const CLEAR_COLOR: u32 = 0x68_B0_D8_FF;
 
 fn main() {
@@ -81,7 +79,13 @@ fn main() {
         .render_target(width, height, bottom_screen, None)
         .expect("failed to create bottom screen render target");
 
-    let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+
+    let _romfs = ctru::services::romfs::RomFS::new().unwrap();
+
+    let shader = {
+        let shader_bytes = std::fs::read("romfs:/vshader.shbin").unwrap();
+        shader::Library::from_bytes(shader_bytes).unwrap()
+    };
 
     let program = shader::Program::new(shader, 0).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -281,8 +281,9 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
     let mut buf_info = buffer::Info::new();
@@ -333,10 +334,10 @@ fn main() {
 
     // Setup the rotating view of the cube
     let mut view = Matrix4::identity();
-    let model_idx = program.get_uniform("modelView").unwrap();
+    let model_idx = program.get_vertex_uniform("modelView").unwrap();
     view.translate(0.0, 0.0, -2.0);
 
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
 
     let stage0 = texenv::TexEnv::new()
         .src(

--- a/citro3d/examples/fragment-light.rs
+++ b/citro3d/examples/fragment-light.rs
@@ -281,9 +281,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
     let mut buf_info = buffer::Info::new();

--- a/citro3d/examples/geometry.rs
+++ b/citro3d/examples/geometry.rs
@@ -1,15 +1,12 @@
-//! This example demonstrates the most basic usage of `citro3d`: rendering a simple
-//! RGB triangle (sometimes called a "Hello triangle") to the 3DS screen.
-
 #![feature(allocator_api)]
 
 use citro3d::macros::include_shader;
-use citro3d::math::{AspectRatio, ClipPlanes, Matrix4, Projection, StereoDisplacement};
+use citro3d::math::{ClipPlanes, Matrix4, Projection};
 use citro3d::render::{ClearFlags, Frame, ScreenTarget, Target};
 use citro3d::texenv;
 use citro3d::{attrib, buffer, shader};
 use ctru::prelude::*;
-use ctru::services::gfx::{RawFrameBuffer, Screen, TopScreen3D};
+use ctru::services::gfx::{RawFrameBuffer, Screen};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -34,25 +31,29 @@ struct Vertex {
 
 static VERTICES: &[Vertex] = &[
     Vertex {
-        pos: Vec3::new(0.0, 0.5, -3.0),
+        pos: Vec3::new(200.0, 200.0, -0.5),
         color: Vec3::new(1.0, 0.0, 0.0),
     },
     Vertex {
-        pos: Vec3::new(-0.5, -0.5, -3.0),
+        pos: Vec3::new(100.0, 40.0, -0.5),
         color: Vec3::new(0.0, 1.0, 0.0),
     },
     Vertex {
-        pos: Vec3::new(0.5, -0.5, -3.0),
+        pos: Vec3::new(300.0, 40.0, -0.5),
         color: Vec3::new(0.0, 0.0, 1.0),
     },
 ];
 
-static SHADER_BYTES: &[u8] = include_shader!("assets/vshader.pica");
+static VERTEX_SHADER: &[u8] = include_shader!("assets/vshader_geo.pica");
+static GEOMETRY_SHADER: &[u8] = include_shader!("assets/gshader_geo.pica");
+
 const CLEAR_COLOR: u32 = 0x68_B0_D8_FF;
 
 fn main() {
     let mut soc = Soc::new().expect("failed to get SOC");
     drop(soc.redirect_to_3dslink(true, true));
+
+    println!("soc initialized");
 
     let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
     let mut hid = Hid::new().expect("Couldn't obtain HID controller");
@@ -60,18 +61,11 @@ fn main() {
 
     let mut instance = citro3d::Instance::new().expect("failed to initialize Citro3D");
 
-    let top_screen = TopScreen3D::from(&gfx.top_screen);
-
-    let (mut top_left, mut top_right) = top_screen.split_mut();
-
-    let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
-    let mut top_left_target = instance
-        .render_target(width, height, top_left, None)
-        .expect("failed to create render target");
-
-    let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
-    let mut top_right_target = instance
-        .render_target(width, height, top_right, None)
+    let mut top_screen = gfx.top_screen.borrow_mut();
+    let RawFrameBuffer { width, height, .. } = top_screen.raw_framebuffer();
+    
+    let mut top_target = instance
+        .render_target(width, height, top_screen, None)
         .expect("failed to create render target");
 
     let mut bottom_screen = gfx.bottom_screen.borrow_mut();
@@ -81,11 +75,16 @@ fn main() {
         .render_target(width, height, bottom_screen, None)
         .expect("failed to create bottom screen render target");
 
-    let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
+    let vertex_library = shader::Library::from_bytes(VERTEX_SHADER).unwrap();
+    let vertex_shader = vertex_library.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
-    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
+    let geometry_library = shader::Library::from_bytes(GEOMETRY_SHADER).unwrap();
+    let geometry_shader = geometry_library.get(0).unwrap();
+
+    let mut program = shader::Program::new(vertex_shader).unwrap();
+    program.set_geometry_shader(geometry_shader, 6).unwrap();
+
+    let projection_uniform_idx = program.get_geometry_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
 
@@ -95,6 +94,15 @@ fn main() {
     let stage0 = texenv::TexEnv::new()
         .src(texenv::Mode::BOTH, texenv::Source::PrimaryColor, None, None)
         .func(texenv::Mode::BOTH, texenv::CombineFunc::Replace);
+
+    let projection = Projection::orthographic(
+        0.0..240.0,
+        0.0..400.0,
+        ClipPlanes {
+            near: 0.0,
+            far: 1.0,
+        },
+    ).into();
 
     while apt.main_loop() {
         hid.scan_input();
@@ -117,32 +125,22 @@ fn main() {
                 frame
                     .select_render_target(target)
                     .expect("failed to set render target");
-                frame.bind_vertex_uniform(projection_uniform_idx, projection);
+                frame.bind_geometry_uniform(projection_uniform_idx, projection);
 
                 frame.set_texenvs(&[stage0]);
 
                 frame.set_attr_info(&attr_info);
 
                 frame
-                    .draw_arrays(buffer::Primitive::Triangles, &buf_info, None)
+                    .draw_arrays(buffer::Primitive::GeometryPrim, &buf_info, None)
                     .unwrap();
             });
 
-            // We bind the vertex shader.
+            // We bind the vertex and geometry shaders.
             frame.bind_program(&program);
 
-            // Configure the first fragment shading substage to just pass through the vertex color
-            // See https://www.opengl.org/sdk/docs/man2/xhtml/glTexEnv.xml for more insight
-
-            let Projections {
-                left_eye,
-                right_eye,
-                center,
-            } = calculate_projections();
-
-            render_to(&mut frame, &mut top_left_target, &left_eye);
-            render_to(&mut frame, &mut top_right_target, &right_eye);
-            render_to(&mut frame, &mut bottom_target, &center);
+            render_to(&mut frame, &mut top_target, &projection);
+            render_to(&mut frame, &mut bottom_target, &projection);
 
             frame
         });
@@ -164,40 +162,4 @@ fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib
     buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
-}
-
-struct Projections {
-    left_eye: Matrix4,
-    right_eye: Matrix4,
-    center: Matrix4,
-}
-
-fn calculate_projections() -> Projections {
-    // TODO: it would be cool to allow playing around with these parameters on
-    // the fly with D-pad, etc.
-    let slider_val = ctru::os::current_3d_slider_state();
-    let interocular_distance = slider_val / 2.0;
-
-    let vertical_fov = 40.0_f32.to_radians();
-    let screen_depth = 2.0;
-
-    let clip_planes = ClipPlanes {
-        near: 0.01,
-        far: 100.0,
-    };
-
-    let (left, right) = StereoDisplacement::new(interocular_distance, screen_depth);
-
-    let (left_eye, right_eye) =
-        Projection::perspective(vertical_fov, AspectRatio::TopScreen, clip_planes)
-            .stereo_matrices(left, right);
-
-    let center =
-        Projection::perspective(vertical_fov, AspectRatio::BottomScreen, clip_planes).into();
-
-    Projections {
-        left_eye,
-        right_eye,
-        center,
-    }
 }

--- a/citro3d/examples/multiple-buffers.rs
+++ b/citro3d/examples/multiple-buffers.rs
@@ -72,9 +72,10 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
 
     let vbo_pos = buffer::Buffer::new(VERTEX_POSITIONS);
     let vbo_col = buffer::Buffer::new(VERTEX_COLS);

--- a/citro3d/examples/multiple-buffers.rs
+++ b/citro3d/examples/multiple-buffers.rs
@@ -72,9 +72,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
 
     let vbo_pos = buffer::Buffer::new(VERTEX_POSITIONS);

--- a/citro3d/examples/render-to-texture.rs
+++ b/citro3d/examples/render-to-texture.rs
@@ -110,9 +110,10 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
 

--- a/citro3d/examples/render-to-texture.rs
+++ b/citro3d/examples/render-to-texture.rs
@@ -110,9 +110,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);

--- a/citro3d/examples/shared-library.rs
+++ b/citro3d/examples/shared-library.rs
@@ -1,15 +1,13 @@
-//! This example demonstrates the most basic usage of `citro3d`: rendering a simple
-//! RGB triangle (sometimes called a "Hello triangle") to the 3DS screen.
-
 #![feature(allocator_api)]
 
-use citro3d::macros::include_shader;
-use citro3d::math::{AspectRatio, ClipPlanes, Matrix4, Projection, StereoDisplacement};
+use std::rc::Rc;
+
+use citro3d::math::{ClipPlanes, Matrix4, Projection};
 use citro3d::render::{ClearFlags, Frame, ScreenTarget, Target};
 use citro3d::texenv;
 use citro3d::{attrib, buffer, shader};
 use ctru::prelude::*;
-use ctru::services::gfx::{RawFrameBuffer, Screen, TopScreen3D};
+use ctru::services::gfx::{RawFrameBuffer, Screen};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -34,25 +32,28 @@ struct Vertex {
 
 static VERTICES: &[Vertex] = &[
     Vertex {
-        pos: Vec3::new(0.0, 0.5, -3.0),
+        pos: Vec3::new(200.0, 200.0, -0.5),
         color: Vec3::new(1.0, 0.0, 0.0),
     },
     Vertex {
-        pos: Vec3::new(-0.5, -0.5, -3.0),
+        pos: Vec3::new(100.0, 40.0, -0.5),
         color: Vec3::new(0.0, 1.0, 0.0),
     },
     Vertex {
-        pos: Vec3::new(0.5, -0.5, -3.0),
+        pos: Vec3::new(300.0, 40.0, -0.5),
         color: Vec3::new(0.0, 0.0, 1.0),
     },
 ];
 
-static SHADER_BYTES: &[u8] = include_shader!("assets/vshader.pica");
+static SHADER_BYTES: &[u8] = include_bytes!("assets/shader.shbin");
+
 const CLEAR_COLOR: u32 = 0x68_B0_D8_FF;
 
 fn main() {
     let mut soc = Soc::new().expect("failed to get SOC");
     drop(soc.redirect_to_3dslink(true, true));
+
+    println!("soc initialized");
 
     let gfx = Gfx::new().expect("Couldn't obtain GFX controller");
     let mut hid = Hid::new().expect("Couldn't obtain HID controller");
@@ -60,18 +61,11 @@ fn main() {
 
     let mut instance = citro3d::Instance::new().expect("failed to initialize Citro3D");
 
-    let top_screen = TopScreen3D::from(&gfx.top_screen);
-
-    let (mut top_left, mut top_right) = top_screen.split_mut();
-
-    let RawFrameBuffer { width, height, .. } = top_left.raw_framebuffer();
-    let mut top_left_target = instance
-        .render_target(width, height, top_left, None)
-        .expect("failed to create render target");
-
-    let RawFrameBuffer { width, height, .. } = top_right.raw_framebuffer();
-    let mut top_right_target = instance
-        .render_target(width, height, top_right, None)
+    let mut top_screen = gfx.top_screen.borrow_mut();
+    let RawFrameBuffer { width, height, .. } = top_screen.raw_framebuffer();
+    
+    let mut top_target = instance
+        .render_target(width, height, top_screen, None)
         .expect("failed to create render target");
 
     let mut bottom_screen = gfx.bottom_screen.borrow_mut();
@@ -81,11 +75,14 @@ fn main() {
         .render_target(width, height, bottom_screen, None)
         .expect("failed to create bottom screen render target");
 
-    let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
+    let shader = Rc::new(shader::Library::from_bytes(SHADER_BYTES).unwrap());
+    let vertex_shader = shader.clone().get_shared(0).unwrap();
+    let geometry_shader = shader.get_shared(1).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
-    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
+    let mut program = shader::Program::new(vertex_shader).unwrap();
+    program.set_geometry_shader(geometry_shader, 6).unwrap();
+
+    let projection_uniform_idx = program.get_geometry_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
 
@@ -95,6 +92,15 @@ fn main() {
     let stage0 = texenv::TexEnv::new()
         .src(texenv::Mode::BOTH, texenv::Source::PrimaryColor, None, None)
         .func(texenv::Mode::BOTH, texenv::CombineFunc::Replace);
+
+    let projection = Projection::orthographic(
+        0.0..240.0,
+        0.0..400.0,
+        ClipPlanes {
+            near: 0.0,
+            far: 1.0,
+        },
+    ).into();
 
     while apt.main_loop() {
         hid.scan_input();
@@ -117,32 +123,22 @@ fn main() {
                 frame
                     .select_render_target(target)
                     .expect("failed to set render target");
-                frame.bind_vertex_uniform(projection_uniform_idx, projection);
+                frame.bind_geometry_uniform(projection_uniform_idx, projection);
 
                 frame.set_texenvs(&[stage0]);
 
                 frame.set_attr_info(&attr_info);
 
                 frame
-                    .draw_arrays(buffer::Primitive::Triangles, &buf_info, None)
+                    .draw_arrays(buffer::Primitive::GeometryPrim, &buf_info, None)
                     .unwrap();
             });
 
-            // We bind the vertex shader.
+            // We bind the vertex and geometry shaders.
             frame.bind_program(&program);
 
-            // Configure the first fragment shading substage to just pass through the vertex color
-            // See https://www.opengl.org/sdk/docs/man2/xhtml/glTexEnv.xml for more insight
-
-            let Projections {
-                left_eye,
-                right_eye,
-                center,
-            } = calculate_projections();
-
-            render_to(&mut frame, &mut top_left_target, &left_eye);
-            render_to(&mut frame, &mut top_right_target, &right_eye);
-            render_to(&mut frame, &mut bottom_target, &center);
+            render_to(&mut frame, &mut top_target, &projection);
+            render_to(&mut frame, &mut bottom_target, &projection);
 
             frame
         });
@@ -164,40 +160,4 @@ fn prepare_vbos(buf_info: &mut buffer::Info, vbo_data: buffer::Buffer) -> attrib
     buf_info.add(vbo_data, attr_info.permutation()).unwrap();
 
     attr_info
-}
-
-struct Projections {
-    left_eye: Matrix4,
-    right_eye: Matrix4,
-    center: Matrix4,
-}
-
-fn calculate_projections() -> Projections {
-    // TODO: it would be cool to allow playing around with these parameters on
-    // the fly with D-pad, etc.
-    let slider_val = ctru::os::current_3d_slider_state();
-    let interocular_distance = slider_val / 2.0;
-
-    let vertical_fov = 40.0_f32.to_radians();
-    let screen_depth = 2.0;
-
-    let clip_planes = ClipPlanes {
-        near: 0.01,
-        far: 100.0,
-    };
-
-    let (left, right) = StereoDisplacement::new(interocular_distance, screen_depth);
-
-    let (left_eye, right_eye) =
-        Projection::perspective(vertical_fov, AspectRatio::TopScreen, clip_planes)
-            .stereo_matrices(left, right);
-
-    let center =
-        Projection::perspective(vertical_fov, AspectRatio::BottomScreen, clip_planes).into();
-
-    Projections {
-        left_eye,
-        right_eye,
-        center,
-    }
 }

--- a/citro3d/examples/skybox.rs
+++ b/citro3d/examples/skybox.rs
@@ -129,9 +129,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
     let model_view_uniform_idx = program.get_uniform("modelView").unwrap();
 

--- a/citro3d/examples/skybox.rs
+++ b/citro3d/examples/skybox.rs
@@ -129,10 +129,11 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
-    let model_view_uniform_idx = program.get_uniform("modelView").unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
+    let model_view_uniform_idx = program.get_vertex_uniform("modelView").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
     let mut buf_info = buffer::Info::new();

--- a/citro3d/examples/textured.rs
+++ b/citro3d/examples/textured.rs
@@ -105,9 +105,10 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
+    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(shader, 0).unwrap();
-    let projection_uniform_idx = program.get_uniform("projection").unwrap();
+    let program = shader::Program::new(vertex_shader).unwrap();
+    let projection_uniform_idx = program.get_vertex_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);
 

--- a/citro3d/examples/textured.rs
+++ b/citro3d/examples/textured.rs
@@ -105,9 +105,8 @@ fn main() {
         .expect("failed to create bottom screen render target");
 
     let shader = shader::Library::from_bytes(SHADER_BYTES).unwrap();
-    let vertex_shader = shader.get(0).unwrap();
 
-    let program = shader::Program::new(vertex_shader).unwrap();
+    let program = shader::Program::new(shader, 0).unwrap();
     let projection_uniform_idx = program.get_uniform("projection").unwrap();
 
     let vbo_data = buffer::Buffer::new(VERTICES);

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -4,6 +4,7 @@
 //! For more details about the PICA200 compiler / shader language, see
 //! documentation for <https://github.com/devkitPro/picasso>.
 
+use std::borrow::Cow;
 use std::error::Error;
 use std::ffi::CString;
 use std::mem::MaybeUninit;
@@ -20,6 +21,7 @@ use crate::uniform;
 #[must_use]
 pub struct Program {
     program: ctru_sys::shaderProgram_s,
+    _shader: Library,
 }
 
 impl Program {
@@ -29,10 +31,15 @@ impl Program {
     ///
     /// Returns an error if:
     /// * the shader program cannot be initialized
-    /// * the input shader is not a vertex shader or is otherwise invalid
+    /// * the shader at the specified index is not a vertex shader or is otherwise invalid or
+    /// missing 
     #[doc(alias = "shaderProgramInit")]
     #[doc(alias = "shaderProgramSetVsh")]
-    pub fn new(vertex_shader: Entrypoint) -> Result<Self, ctru::Error> {
+    pub fn new(shader: Library, vertex_shader_index: usize) -> Result<Self, ctru::Error> {
+        let vertex_shader = shader
+            .get(vertex_shader_index)
+            .ok_or_else(|| ctru::Error::Other(String::from("Invalid index")))?;
+
         let mut program = unsafe {
             let mut program = MaybeUninit::uninit();
             let result = ctru_sys::shaderProgramInit(program.as_mut_ptr());
@@ -45,7 +52,10 @@ impl Program {
         let ret = unsafe { ctru_sys::shaderProgramSetVsh(&mut program, vertex_shader.as_raw()) };
 
         if ret == 0 {
-            Ok(Self { program })
+            Ok(Self {
+                program,
+                _shader: shader,
+            })
         } else {
             Err(ctru::Error::from(ret))
         }
@@ -137,7 +147,10 @@ impl From<Type> for u8 {
 /// This is the result of parsing a shader binary (`.shbin`), and the resulting
 /// [`Entrypoint`]s can be used as part of a [`Program`].
 #[doc(alias = "DVLB_s")]
-pub struct Library(*mut ctru_sys::DVLB_s);
+pub struct Library {
+    dvlb: *mut ctru_sys::DVLB_s,
+    bytes: Cow<'static, [u8]>
+}
 
 impl Library {
     /// Parse a new shader library from input bytes.
@@ -147,9 +160,11 @@ impl Library {
     /// An error is returned if the input data does not have an alignment of 4
     /// (cannot be safely converted to `&[u32]`).
     #[doc(alias = "DVLB_ParseFile")]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Box<dyn Error>> {
-        let aligned: &[u32] = bytemuck::try_cast_slice(bytes)?;
-        Ok(Self(unsafe {
+    pub fn from_bytes<B: Into<Cow<'static, [u8]>>>(bytes: B) -> Result<Self, Box<dyn Error>> {
+        let bytes = bytes.into();
+
+        let aligned: &[u32] = bytemuck::try_cast_slice(&bytes)?;
+        let dvlb = unsafe {
             ctru_sys::DVLB_ParseFile(
                 // SAFETY: we're trusting the parse implementation doesn't mutate
                 // the contents of the data. From a quick read it looks like that's
@@ -157,14 +172,19 @@ impl Library {
                 aligned.as_ptr().cast_mut(),
                 aligned.len().try_into()?,
             )
-        }))
+        };
+
+        Ok(Self {
+            dvlb,
+            bytes,
+        })
     }
 
     /// Get the number of [`Entrypoint`]s in this shader library.
     #[must_use]
     #[doc(alias = "numDVLE")]
     pub fn len(&self) -> usize {
-        unsafe { (*self.0).numDVLE as usize }
+        unsafe { (*self.dvlb).numDVLE as usize }
     }
 
     /// Whether the library has any [`Entrypoint`]s or not.
@@ -178,7 +198,7 @@ impl Library {
     pub fn get(&self, index: usize) -> Option<Entrypoint<'_>> {
         if index < self.len() {
             Some(Entrypoint {
-                ptr: unsafe { (*self.0).DVLE.add(index) },
+                ptr: unsafe { (*self.dvlb).DVLE.add(index) },
                 _library: self,
             })
         } else {
@@ -187,7 +207,7 @@ impl Library {
     }
 
     fn as_raw(&mut self) -> *mut ctru_sys::DVLB_s {
-        self.0
+        self.dvlb
     }
 }
 

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::error::Error;
 use std::ffi::CString;
 use std::mem::MaybeUninit;
+use std::rc::Rc;
 
 use crate::uniform;
 
@@ -21,7 +22,8 @@ use crate::uniform;
 #[must_use]
 pub struct Program {
     program: ctru_sys::shaderProgram_s,
-    _shader: Library,
+    _vsh: Entrypoint,
+    gsh: Option<Entrypoint>,
 }
 
 impl Program {
@@ -31,15 +33,10 @@ impl Program {
     ///
     /// Returns an error if:
     /// * the shader program cannot be initialized
-    /// * the shader at the specified index is not a vertex shader or is otherwise invalid or
-    /// missing 
+    /// * the input shader is not a vertex shader or is otherwise invalid
     #[doc(alias = "shaderProgramInit")]
     #[doc(alias = "shaderProgramSetVsh")]
-    pub fn new(shader: Library, vertex_shader_index: usize) -> Result<Self, ctru::Error> {
-        let vertex_shader = shader
-            .get(vertex_shader_index)
-            .ok_or_else(|| ctru::Error::Other(String::from("Invalid index")))?;
-
+    pub fn new(mut vertex_shader: Entrypoint) -> Result<Self, ctru::Error> {
         let mut program = unsafe {
             let mut program = MaybeUninit::uninit();
             let result = ctru_sys::shaderProgramInit(program.as_mut_ptr());
@@ -54,7 +51,8 @@ impl Program {
         if ret == 0 {
             Ok(Self {
                 program,
-                _shader: shader,
+                _vsh: vertex_shader,
+                gsh: None,
             })
         } else {
             Err(ctru::Error::from(ret))
@@ -70,7 +68,7 @@ impl Program {
     #[doc(alias = "shaderProgramSetGsh")]
     pub fn set_geometry_shader(
         &mut self,
-        geometry_shader: Entrypoint,
+        mut geometry_shader: Entrypoint,
         stride: u8,
     ) -> Result<(), ctru::Error> {
         let ret = unsafe {
@@ -78,20 +76,21 @@ impl Program {
         };
 
         if ret == 0 {
+            self.gsh = Some(geometry_shader);
             Ok(())
         } else {
             Err(ctru::Error::from(ret))
         }
     }
 
-    /// Get the index of a uniform by name.
+    /// Get the index of a uniform in the vertex shader by name.
     ///
     /// # Errors
     ///
     /// * If the given `name` contains a null byte
     /// * If a uniform with the given `name` could not be found
     #[doc(alias = "shaderInstanceGetUniformLocation")]
-    pub fn get_uniform(&self, name: &str) -> crate::Result<uniform::Index> {
+    pub fn get_vertex_uniform(&self, name: &str) -> crate::Result<uniform::Index> {
         let vertex_instance = unsafe { (*self.as_raw()).vertexShader };
         assert!(
             !vertex_instance.is_null(),
@@ -102,6 +101,33 @@ impl Program {
 
         let idx =
             unsafe { ctru_sys::shaderInstanceGetUniformLocation(vertex_instance, name.as_ptr()) };
+
+        if idx < 0 {
+            Err(crate::Error::NotFound)
+        } else {
+            Ok((idx as u8).into())
+        }
+    }
+
+    /// Get the index of a uniform in the geometry shader by name.
+    ///
+    /// # Errors
+    ///
+    /// * If a geometry shader has not been set
+    /// * If the given `name` contains a null byte
+    /// * If a uniform with the given `name` could not be found
+    #[doc(alias = "shaderInstanceGetUniformLocation")]
+    pub fn get_geometry_uniform(&self, name: &str) -> crate::Result<uniform::Index> {
+        if self.gsh.is_none() {
+            return Err(crate::Error::MissingProgram);
+        }
+
+        let geometry_instance = unsafe { (*self.as_raw()).geometryShader };
+
+        let name = CString::new(name)?;
+
+        let idx =
+            unsafe { ctru_sys::shaderInstanceGetUniformLocation(geometry_instance, name.as_ptr()) };
 
         if idx < 0 {
             Err(crate::Error::NotFound)
@@ -149,7 +175,7 @@ impl From<Type> for u8 {
 #[doc(alias = "DVLB_s")]
 pub struct Library {
     dvlb: *mut ctru_sys::DVLB_s,
-    _bytes: Cow<'static, [u8]>
+    _bytes: Cow<'static, [u8]>,
 }
 
 impl Library {
@@ -195,11 +221,27 @@ impl Library {
 
     /// Get the [`Entrypoint`] at the given index, if present.
     #[must_use]
-    pub fn get(&self, index: usize) -> Option<Entrypoint<'_>> {
+    pub fn get(self, index: usize) -> Option<Entrypoint> {
         if index < self.len() {
             Some(Entrypoint {
                 ptr: unsafe { (*self.dvlb).DVLE.add(index) },
-                _library: self,
+                _library: MaybeRc::Owned(self),
+            })
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    /// Get the [`Entrypoint`] at the given index, if present.
+    ///
+    /// Like [`Library::get`], except takes `Rc<Self>` instead of `Self`, to allow the same library
+    /// to have multiple entrypoints
+    pub fn get_shared(self: Rc<Self>, index: usize) -> Option<Entrypoint> {
+        if index < self.len() {
+            Some(Entrypoint {
+                ptr: unsafe { (*self.dvlb).DVLE.add(index) },
+                _library: MaybeRc::Shared(self),
             })
         } else {
             None
@@ -220,16 +262,21 @@ impl Drop for Library {
     }
 }
 
-/// A shader library entrypoint (also called DVLE). This represents either a
-/// vertex or a geometry shader.
-#[derive(Clone, Copy)]
-pub struct Entrypoint<'lib> {
-    ptr: *mut ctru_sys::DVLE_s,
-    _library: &'lib Library,
+#[allow(dead_code)]
+enum MaybeRc<T> {
+    Owned(T),
+    Shared(Rc<T>),
 }
 
-impl<'lib> Entrypoint<'lib> {
-    fn as_raw(self) -> *mut ctru_sys::DVLE_s {
+/// A shader library entrypoint (also called DVLE). This represents either a
+/// vertex or a geometry shader.
+pub struct Entrypoint {
+    ptr: *mut ctru_sys::DVLE_s,
+    _library: MaybeRc<Library>,
+}
+
+impl Entrypoint {
+    fn as_raw(&mut self) -> *mut ctru_sys::DVLE_s {
         self.ptr
     }
 }

--- a/citro3d/src/shader.rs
+++ b/citro3d/src/shader.rs
@@ -149,7 +149,7 @@ impl From<Type> for u8 {
 #[doc(alias = "DVLB_s")]
 pub struct Library {
     dvlb: *mut ctru_sys::DVLB_s,
-    bytes: Cow<'static, [u8]>
+    _bytes: Cow<'static, [u8]>
 }
 
 impl Library {
@@ -176,7 +176,7 @@ impl Library {
 
         Ok(Self {
             dvlb,
-            bytes,
+            _bytes: bytes,
         })
     }
 


### PR DESCRIPTION
This should fix both use-after-errors mentioned in #53, by making `shader::Program` own the `shader::Library` that it uses, and by making `shader::Library` own the underlying bytes of the compiled shader.